### PR TITLE
Support door sensor of keyturner

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This module builds an ESPHome lock platform for Nuki Smartlock (nuki_lock) that 
 
 The lock entity is updated whenever the look changes state (via Nuki App, HA, or manually) using Nuki BT advertisement mechanism.
 
-![image](https://user-images.githubusercontent.com/1754967/183265529-48482e93-c5f0-4d30-ab16-fdc6ea3753ce.png)
+![screenshot](https://user-images.githubusercontent.com/1754967/183266065-d1a6e9fe-d7f7-4295-9c0d-4bf9235bf4cd.png)
 
 ## How to use
 Add the following to the ESPHome yaml file:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ lock:
       name: "Nuki Battery Critical"
     battery_level:
       name: "Nuki Battery Level"
+    door_sensor:
+      name: "Nuki Door Sensor"
+    door_sensor_state:
+      name: "Nuki Door Sensor State"
 ```
 
 After running ESPHome (esphome run <yamlfile.yaml>), the module will actively try to pair to Nuki.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The lock entity is updated whenever the look changes state (via Nuki App, HA, or
 
 ![image](https://user-images.githubusercontent.com/1754967/183265529-48482e93-c5f0-4d30-ab16-fdc6ea3753ce.png)
 
-
 ## How to use
 Add the following to the ESPHome yaml file:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This module builds an ESPHome lock platform for Nuki Smartlock (nuki_lock) that 
 
 The lock entity is updated whenever the look changes state (via Nuki App, HA, or manually) using Nuki BT advertisement mechanism.
 
-![image](https://user-images.githubusercontent.com/74111540/182619954-930b6c6c-99c8-4ece-a4e3-5fc43460110a.png)
+![image](https://user-images.githubusercontent.com/1754967/183265529-48482e93-c5f0-4d30-ab16-fdc6ea3753ce.png)
+
 
 ## How to use
 Add the following to the ESPHome yaml file:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ This module builds an ESPHome lock platform for Nuki Smartlock (nuki_lock) that 
 - Lock 
 - Binary Sensor: Critical Battery 
 - Sensor: Battery Level
-- Binary Sensor: Is Paired 
+- Binary Sensor: Is Paired
+- Binary Sensor: Door Sensor
+- Text Sensor: Door Sensor State
 
 The lock entity is updated whenever the look changes state (via Nuki App, HA, or manually) using Nuki BT advertisement mechanism.
 

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -1,14 +1,16 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import lock, binary_sensor, sensor, switch
-from esphome.const import CONF_ID, CONF_BATTERY_LEVEL, DEVICE_CLASS_CONNECTIVITY, DEVICE_CLASS_BATTERY, UNIT_PERCENT, ENTITY_CATEGORY_CONFIG
+from esphome.components import lock, binary_sensor, text_sensor, sensor, switch
+from esphome.const import CONF_ID, CONF_BATTERY_LEVEL, DEVICE_CLASS_CONNECTIVITY, DEVICE_CLASS_BATTERY, DEVICE_CLASS_DOOR, UNIT_PERCENT, ENTITY_CATEGORY_CONFIG
 
-AUTO_LOAD = ["binary_sensor", "sensor", "switch"]
+AUTO_LOAD = ["binary_sensor", "text_sensor", "sensor", "switch"]
 
 CONF_IS_PAIRED = "is_paired"
 CONF_UNPAIR = "unpair"
 CONF_BATTERY_CRITICAL = "battery_critical"
 CONF_BATTERY_LEVEL = "battery_level"
+CONF_DOOR_SENSOR = "door_sensor"
+CONF_DOOR_SENSOR_STATE = "door_sensor_state"
 
 nuki_lock_ns = cg.esphome_ns.namespace('nuki_lock')
 NukiLock = nuki_lock_ns.class_('NukiLock', lock.Lock, switch.Switch, cg.Component)
@@ -25,6 +27,10 @@ CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend({
                     device_class=DEVICE_CLASS_BATTERY,
                     unit_of_measurement=UNIT_PERCENT,
                 ),
+    cv.Optional(CONF_DOOR_SENSOR): binary_sensor.binary_sensor_schema(
+                    device_class=DEVICE_CLASS_DOOR,
+                ),
+    cv.Optional(CONF_DOOR_SENSOR_STATE): text_sensor.text_sensor_schema(),
     cv.Optional(CONF_UNPAIR, default=False): cv.boolean,
 }).extend(cv.polling_component_schema("500ms"))
 
@@ -46,5 +52,14 @@ async def to_code(config):
         sens = await sensor.new_sensor(config[CONF_BATTERY_LEVEL])
         cg.add(var.set_battery_level(sens))
 
+    if CONF_DOOR_SENSOR in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_DOOR_SENSOR])
+        cg.add(var.set_door_sensor(sens))
+
+    if CONF_DOOR_SENSOR_STATE in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_DOOR_SENSOR_STATE])
+        cg.add(var.set_door_sensor_state(sens))
+
     if CONF_UNPAIR in config:
         cg.add(var.set_unpair(config[CONF_UNPAIR]))
+    

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -61,10 +61,14 @@ void NukiLock::update_status()
           this->retrievedKeyTurnerState_.currentTimeMinute, 
           this->retrievedKeyTurnerState_.currentTimeSecond);
         this->publish_state(this->nuki_to_lock_state(this->retrievedKeyTurnerState_.lockState));
-        this->battery_critical_->publish_state(this->nukiBle_->isBatteryCritical());
-        this->battery_level_->publish_state(this->nukiBle_->getBatteryPerc());
-        this->door_sensor_->publish_state(this->nuki_doorsensor_to_binary(this->retrievedKeyTurnerState_.doorSensorState));
-        this->door_sensor_state_->publish_state(this->nuki_doorsensor_to_string(this->retrievedKeyTurnerState_.doorSensorState));
+        if (this->battery_critical_ != nullptr)
+            this->battery_critical_->publish_state(this->nukiBle_->isBatteryCritical());
+        if (this->battery_level_ != nullptr)
+            this->battery_level_->publish_state(this->nukiBle_->getBatteryPerc());
+        if (this->door_sensor_ != nullptr)
+            this->door_sensor_->publish_state(this->nuki_doorsensor_to_binary(this->retrievedKeyTurnerState_.doorSensorState));
+        if (this->door_sensor_state_ != nullptr)
+            this->door_sensor_state_->publish_state(this->nuki_doorsensor_to_string(this->retrievedKeyTurnerState_.doorSensorState));
     } else {
         ESP_LOGE(TAG, "requestKeyTurnerState failed: %d", result);
     }  

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -21,6 +21,34 @@ lock::LockState NukiLock::nuki_to_lock_state(Nuki::LockState nukiLockState) {
     }
 }
 
+bool NukiLock::nuki_doorsensor_to_binary(Nuki::DoorSensorState nukiDoorSensorState) {
+    switch(nukiDoorSensorState) {
+        case Nuki::DoorSensorState::DoorClosed:
+            return false;
+        default:
+            return true;
+    }
+}
+
+std::string NukiLock::nuki_doorsensor_to_string(Nuki::DoorSensorState nukiDoorSensorState) {
+    switch(nukiDoorSensorState) {
+        case Nuki::DoorSensorState::Unavailable:
+            return "unavailable";
+        case Nuki::DoorSensorState::Deactivated:
+            return "deactivated";
+        case Nuki::DoorSensorState::DoorClosed:
+            return "closed";
+        case Nuki::DoorSensorState::DoorOpened:
+            return "opened";
+        case Nuki::DoorSensorState::DoorStateUnknown:
+            return "unknown";
+        case Nuki::DoorSensorState::Calibrating:
+            return "calibrating";
+        default:
+            return "undefined";
+    }
+}
+
 void NukiLock::update_status()
 {
     this->status_update_ = false;
@@ -35,6 +63,8 @@ void NukiLock::update_status()
         this->publish_state(this->nuki_to_lock_state(this->retrievedKeyTurnerState_.lockState));
         this->battery_critical_->publish_state(this->nukiBle_->isBatteryCritical());
         this->battery_level_->publish_state(this->nukiBle_->getBatteryPerc());
+        this->door_sensor_->publish_state(this->nuki_doorsensor_to_binary(this->retrievedKeyTurnerState_.doorSensorState));
+        this->door_sensor_state_->publish_state(this->nuki_doorsensor_to_string(this->retrievedKeyTurnerState_.doorSensorState));
     } else {
         ESP_LOGE(TAG, "requestKeyTurnerState failed: %d", result);
     }  
@@ -124,6 +154,8 @@ void NukiLock::dump_config(){
     LOG_LOCK(TAG, "Nuki Lock", this);    
     LOG_BINARY_SENSOR(TAG, "Is Paired", this->is_paired_);
     LOG_BINARY_SENSOR(TAG, "Battery Critical", this->battery_critical_);
+    LOG_BINARY_SENSOR(TAG, "Door Sensor", this->door_sensor_);
+    LOG_TEXT_SENSOR(TAG, "Door Sensor State", this->door_sensor_state_);
     LOG_SENSOR(TAG, "Battery Level", this->battery_level_);
     ESP_LOGCONFIG(TAG, "Unpair request is %s", this->unpair_? "true":"false");
 }

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -4,6 +4,7 @@
 #include "esphome/components/lock/lock.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/text_sensor/text_sensor.h"
 
 #include "NukiBle.h"
 #include "NukiConstants.h"
@@ -38,6 +39,8 @@ class NukiLock : public lock::Lock, public PollingComponent {
         void set_is_paired(binary_sensor::BinarySensor *is_paired) { this->is_paired_ = is_paired; }
         void set_battery_critical(binary_sensor::BinarySensor *battery_critical) { this->battery_critical_ = battery_critical; }
         void set_battery_level(sensor::Sensor *battery_level) { this->battery_level_ = battery_level; }
+        void set_door_sensor(binary_sensor::BinarySensor *door_sensor) { this->door_sensor_ = door_sensor; }
+        void set_door_sensor_state(text_sensor::TextSensor *door_sensor_state) { this->door_sensor_state_ = door_sensor_state; }
         void set_unpair(bool unpair) {this->unpair_ = unpair; }
 
         float get_setup_priority() const override { return setup_priority::HARDWARE - 1.0f; }
@@ -45,6 +48,8 @@ class NukiLock : public lock::Lock, public PollingComponent {
         void dump_config() override;
 
         lock::LockState nuki_to_lock_state(Nuki::LockState);
+        bool nuki_doorsensor_to_binary(Nuki::DoorSensorState);
+        std::string nuki_doorsensor_to_string(Nuki::DoorSensorState nukiDoorSensorState);
 
     protected:
         void control(const lock::LockCall &call) override;
@@ -53,6 +58,8 @@ class NukiLock : public lock::Lock, public PollingComponent {
 
         binary_sensor::BinarySensor *is_paired_;
         binary_sensor::BinarySensor *battery_critical_;
+        binary_sensor::BinarySensor *door_sensor_;
+        text_sensor::TextSensor *door_sensor_state_;
         sensor::Sensor *battery_level_;
         Nuki::NukiBle *nukiBle_;
         BleScanner scanner_;

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -56,11 +56,11 @@ class NukiLock : public lock::Lock, public PollingComponent {
         void update_status();
         void open_latch() override { this->open_latch_ = true; unlock();}
 
-        binary_sensor::BinarySensor *is_paired_;
-        binary_sensor::BinarySensor *battery_critical_;
-        binary_sensor::BinarySensor *door_sensor_;
-        text_sensor::TextSensor *door_sensor_state_;
-        sensor::Sensor *battery_level_;
+        binary_sensor::BinarySensor *is_paired_{nullptr};
+        binary_sensor::BinarySensor *battery_critical_{nullptr};
+        binary_sensor::BinarySensor *door_sensor_{nullptr};
+        text_sensor::TextSensor *door_sensor_state_{nullptr};
+        sensor::Sensor *battery_level_{nullptr};
         Nuki::NukiBle *nukiBle_;
         BleScanner scanner_;
         Nuki::KeyTurnerState retrievedKeyTurnerState_;


### PR DESCRIPTION
Hi,

i added two additional sensors to represent the door sensor.
- door_sensor: Representing a simple binary sensor of device_class "door"
- door_sensor_state: Reflacting all nuki door sensor states as string.

To map the nuki states to a binary sensor, I decided to use DoorClosed as "false" and all other cases as "true". This ensures that if there is something wrong with the door sensor, it shows open instead of closed (more secure).

Thanks for providing this custom component.

best regards
Jochen