### PR TITLE
Fix BLE event handler.

### DIFF
--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -52,7 +52,7 @@ std::string NukiLockComponent::nuki_doorsensor_to_string(Nuki::DoorSensorState n
 void NukiLockComponent::update_status()
 {
     this->status_update_ = false;
-    Nuki::CmdResult result = this->nukiLock.requestKeyTurnerState(&(this->retrievedKeyTurnerState_));
+    Nuki::CmdResult result = this->nukiLock_.requestKeyTurnerState(&(this->retrievedKeyTurnerState_));
 
     if (result == Nuki::CmdResult::Success) {
         ESP_LOGI(TAG, "Bat state: %#x, Bat crit: %d, Bat perc:%d lock state: %d %d:%d:%d",

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -52,21 +52,21 @@ std::string NukiLockComponent::nuki_doorsensor_to_string(Nuki::DoorSensorState n
 void NukiLockComponent::update_status()
 {
     this->status_update_ = false;
-    uint8_t result = this->nukiLock_->requestKeyTurnerState(&(this->retrievedKeyTurnerState_));
+    uint8_t result = this->nukiLock_.requestKeyTurnerState(&(this->retrievedKeyTurnerState_));
 
     if (result == Nuki::CmdResult::Success) {
         ESP_LOGI(TAG, "Bat state: %#x, Bat crit: %d, Bat perc:%d lock state: %d %d:%d:%d",
           this->retrievedKeyTurnerState_.criticalBatteryState,
-          this->nukiLock_->isBatteryCritical(), this->nukiLock_->getBatteryPerc(), this->retrievedKeyTurnerState_.lockState, 
+          this->nukiLock_.isBatteryCritical(), this->nukiLock_.getBatteryPerc(), this->retrievedKeyTurnerState_.lockState,
           this->retrievedKeyTurnerState_.currentTimeHour,
-          this->retrievedKeyTurnerState_.currentTimeMinute, 
+          this->retrievedKeyTurnerState_.currentTimeMinute,
           this->retrievedKeyTurnerState_.currentTimeSecond);
         this->publish_state(this->nuki_to_lock_state(this->retrievedKeyTurnerState_.lockState));
         this->is_connected_->publish_state(true);
         if (this->battery_critical_ != nullptr)
-            this->battery_critical_->publish_state(this->nukiLock_->isBatteryCritical());
+            this->battery_critical_->publish_state(this->nukiLock_.isBatteryCritical());
         if (this->battery_level_ != nullptr)
-            this->battery_level_->publish_state(this->nukiLock_->getBatteryPerc());
+            this->battery_level_->publish_state(this->nukiLock_.getBatteryPerc());
         if (this->door_sensor_ != nullptr)
             this->door_sensor_->publish_state(this->nuki_doorsensor_to_binary(this->retrievedKeyTurnerState_.doorSensorState));
         if (this->door_sensor_state_ != nullptr)
@@ -76,37 +76,34 @@ void NukiLockComponent::update_status()
         this->is_connected_->publish_state(false);
         this->publish_state(lock::LOCK_STATE_NONE);
         this->status_update_ = true;
-    }  
+    }
 }
 
 void NukiLockComponent::setup() {
 
     ESP_LOGI(TAG, "Starting NUKI Lock...");
-    this->nukiLock_ = new NukiLock::NukiLock(this->deviceName_, this->deviceId_);
-    this->handler_ = new nuki_lock::Handler(&(this->status_update_));
 
-    this->traits.set_supported_states(std::set<lock::LockState> {lock::LOCK_STATE_NONE, lock::LOCK_STATE_LOCKED, 
-                                                                 lock::LOCK_STATE_UNLOCKED, lock::LOCK_STATE_JAMMED, 
+    this->traits.set_supported_states(std::set<lock::LockState> {lock::LOCK_STATE_NONE, lock::LOCK_STATE_LOCKED,
+                                                                 lock::LOCK_STATE_UNLOCKED, lock::LOCK_STATE_JAMMED,
                                                                  lock::LOCK_STATE_LOCKING, lock::LOCK_STATE_UNLOCKING});
     this->scanner_.initialize();
-    this->nukiLock_->registerBleScanner(&this->scanner_);
-    this->nukiLock_->initialize();
-    this->nukiLock_->setConnectTimeout(BLE_CONNECT_TIMEOUT_SEC);
-    this->nukiLock_->setConnectRetries(BLE_CONNECT_TIMEOUT_RETRIES);
-    
+    this->nukiLock_.registerBleScanner(&this->scanner_);
+    this->nukiLock_.initialize();
+    this->nukiLock_.setConnectTimeout(BLE_CONNECT_TIMEOUT_SEC);
+    this->nukiLock_.setConnectRetries(BLE_CONNECT_TIMEOUT_RETRIES);
+
     if (this->unpair_) {
         ESP_LOGW(TAG, "Unpair requested");
-        this->nukiLock_->unPairNuki();
+        this->nukiLock_.unPairNuki();
     }
 
-    if (this->nukiLock_->isPairedWithLock()) {
+    if (this->nukiLock_.isPairedWithLock()) {
         this->status_update_ = true;
-        ESP_LOGI(TAG, "%s Nuki paired", this->deviceName_); 
+        ESP_LOGI(TAG, "%s Nuki paired", this->deviceName_);
         this->is_paired_->publish_initial_state(true);
-        this->nukiLock_->setEventHandler(this->handler_);
     }
     else {
-        ESP_LOGW(TAG, "%s Nuki is not paired", this->deviceName_); 
+        ESP_LOGW(TAG, "%s Nuki is not paired", this->deviceName_);
         this->is_paired_->publish_initial_state(false);
     }
 
@@ -119,14 +116,14 @@ void NukiLockComponent::update() {
 
     this->scanner_.update();
 
-    if (this->nukiLock_->isPairedWithLock()) {
+    if (this->nukiLock_.isPairedWithLock()) {
         this->is_paired_->publish_state(true);
         if (this->status_update_) {
             this->update_status();
         }
     }
     else if (! this->unpair_) {
-        bool paired = (this->nukiLock_->pairNuki() == Nuki::PairingResult::Success);
+        bool paired = (this->nukiLock_.pairNuki() == Nuki::PairingResult::Success);
         if (paired) {
             ESP_LOGI(TAG, "Nuki paired");
             this->update_status();
@@ -136,7 +133,7 @@ void NukiLockComponent::update() {
 }
 
 void NukiLockComponent::control(const lock::LockCall &call) {
-    if (!this->nukiLock_->isPairedWithLock()) {
+    if (!this->nukiLock_.isPairedWithLock()) {
         ESP_LOGE(TAG, "Lock/Unlock action called for unpaired nuki");
         return;
     }
@@ -146,7 +143,7 @@ void NukiLockComponent::control(const lock::LockCall &call) {
 
     switch(state){
         case lock::LOCK_STATE_LOCKED:
-            result = this->nukiLock_->lockAction(NukiLock::LockAction::Lock);
+            result = this->nukiLock_.lockAction(NukiLock::LockAction::Lock);
             break;
 
         case lock::LOCK_STATE_UNLOCKED:{
@@ -161,7 +158,7 @@ void NukiLockComponent::control(const lock::LockCall &call) {
                 state = lock::LockState::LOCK_STATE_LOCKING;
             }
 
-            result = this->nukiLock_->lockAction(action);
+            result = this->nukiLock_.lockAction(action);
 
             this->open_latch_ = false;
             this->lock_n_go_ = false;
@@ -190,7 +187,7 @@ void NukiLockComponent::lock_n_go(){
 }
 
 void NukiLockComponent::dump_config(){
-    LOG_LOCK(TAG, "Nuki Lock", this);    
+    LOG_LOCK(TAG, "Nuki Lock", this);
     LOG_BINARY_SENSOR(TAG, "Is Connected", this->is_connected_);
     LOG_BINARY_SENSOR(TAG, "Is Paired", this->is_paired_);
     LOG_BINARY_SENSOR(TAG, "Battery Critical", this->battery_critical_);
@@ -198,6 +195,11 @@ void NukiLockComponent::dump_config(){
     LOG_TEXT_SENSOR(TAG, "Door Sensor State", this->door_sensor_state_);
     LOG_SENSOR(TAG, "Battery Level", this->battery_level_);
     ESP_LOGCONFIG(TAG, "Unpair request is %s", this->unpair_? "true":"false");
+}
+
+void NukiLockComponent::notify(Nuki::EventType eventType) {
+    this->status_update_ = true;
+    ESP_LOGI(TAG, "event notified %d", eventType);
 }
 
 } //namespace nuki_lock


### PR DESCRIPTION
I managed to trace what I think is issue #26 : 
```
[17:44:05]Received AuthorizationId: 06 00 35 22 
[17:44:05]Rec encrypted data: 19 ab 2c b9 47 ff e7 bb 66 2e f5 27 ba 34 cd d6 0e 39 76 3c 24 73 56 17 77 fe a4 12 6e ba 5c 18 b8 db 99 4f cf 4f 0a eb f7 1d 65 3f 02 b6 fe 58 72 56 
[17:44:05]Decrypted data: 06 00 35 22 0c 00 02 03 00 e7 07 06 1a 0f 2c 00 00 00 b8 08 00 03 00 00 00 00 00 00 00 00 f0 00 8b 37 
[17:44:05]keyturnerStates: 02 03 00 e7 07 06 1a 0f 2c 00 00 00 b8 08 00 03 00 00 00 00 00 00 00 00 f0 00 
[17:44:05]Received data: 96 82 bb 46 2a 77 2f e6 d6 78 70 59 96 a1 32 94 7c 1b 62 f6 ff 88 01 28 06 00 35 22 19 00 b0 9a 33 22 de dc 3f 90 eb b6 97 34 f6 59 bd 0e d4 b5 0b 96 87 d1 a0 ad b1 [17:44:05]received nonce: 96 82 bb 46 2a 77 2f e6 d6 78 70 59 96 a1 32 94 7c 1b 62 f6 ff 88 01 28 
[17:44:05]Received AuthorizationId: 06 00 35 22 
[17:44:05]Rec encrypted data: b0 9a 33 22 de dc 3f 90 eb b6 97 34 f6 59 bd 0e d4 b5 0b 96 87 d1 a0 ad b1 
[17:44:05]Decrypted data: 06 00 35 22 0e 00 00 75 be 
[17:44:05]status: 00 
[17:44:15]Guru Meditation Error: Core  0 panic'ed (LoadProhibited). Exception was unhandled.
[17:44:15]
[17:44:15]Core  0 register dump:
[17:44:15]PC      : 0x400e6837  PS      : 0x00060f30  A0      : 0x800e68ef  A1      : 0x3ffd2470  
WARNING Decoded 0x400e6837: Nuki::NukiBle::onResult(NimBLEAdvertisedDevice*) at /home/dam/dm/esphome-configs/.esphome/build/iot-door-lock/.piolibdeps/iot-door-lock/NukiBleEsp/src/NukiBle.cpp:244
 (inlined by) Nuki::NukiBle::onResult(NimBLEAdvertisedDevice*) at /home/dam/dm/esphome-configs/.esphome/build/iot-door-lock/.piolibdeps/iot-door-lock/NukiBleEsp/src/NukiBle.cpp:199
[17:44:15]A2      : 0x3ffbc8b0  A3      : 0x00000000  A4      : 0x00000000  A5      : 0x0000004c  
[17:44:15]A6      : 0x00000004  A7      : 0x3ffdbd3c  A8      : 0x800e682f  A9      : 0x3ffd2450  
[17:44:15]A10     : 0x000000ff  A11     : 0x3ffd248c  A12     : 0x00000019  A13     : 0x00000000  
[17:44:15]A14     : 0x0000002d  A15     : 0x3ffb6c68  SAR     : 0x0000000a  EXCCAUSE: 0x0000001c  
[17:44:15]EXCVADDR: 0x000000ff  LBEG    : 0x400845fd  LEND    : 0x40084605  LCOUNT  : 0x00000027  
[17:44:15]
[17:44:15]
[17:44:15]Backtrace:0x400e6834:0x3ffd24700x400e68ec:0x3ffd2560 0x4019d2ed:0x3ffd2580 0x400e62db:0x3ffd25a0 0x40177fdd:0x3ffd25c0 0x4017b0da:0x3ffd2600 0x401800c9:0x3ffd2670 0x4017ff75:0x3ffd26b0 0x40180391:0x3ffd26d0 0x4017ebf9:0x3ffd26f0 0x4008fb8e:0x3ffd2710 0x40176b9a:0x3ffd2730 
WARNING Found stack trace! Trying to decode it
WARNING Decoded 0x400e6834: Nuki::NukiBle::onResult(NimBLEAdvertisedDevice*) at /home/dam/dm/esphome-configs/.esphome/build/iot-door-lock/.piolibdeps/iot-door-lock/NukiBleEsp/src/NukiBle.cpp:243
 (inlined by) Nuki::NukiBle::onResult(NimBLEAdvertisedDevice*) at /home/dam/dm/esphome-configs/.esphome/build/iot-door-lock/.piolibdeps/iot-door-lock/NukiBleEsp/src/NukiBle.cpp:199
WARNING Decoded 0x400e68ec: non-virtual thunk to Nuki::NukiBle::onResult(NimBLEAdvertisedDevice*)
WARNING Decoded 0x4019d2ed: BleScanner::Scanner::onResult(NimBLEAdvertisedDevice*) at /home/dam/dm/esphome-configs/.esphome/build/iot-door-lock/.piolibdeps/iot-door-lock/BleScanner/src/BleScanner.cpp:85 (discriminator 2)
WARNING Decoded 0x400e62db: non-virtual thunk to BleScanner::Scanner::onResult(NimBLEAdvertisedDevice*)
WARNING Decoded 0x40177fdd: NimBLEScan::handleGapEvent(ble_gap_event*, void*) at /home/dam/dm/esphome-configs/.esphome/build/iot-door-lock/.piolibdeps/iot-door-lock/NimBLE-Arduino/src/NimBLEScan.cpp:153
WARNING Decoded 0x4017b0da: ble_gap_disc_report at /home/dam/dm/esphome-configs/.esphome/build/iot-door-lock/.piolibdeps/iot-door-lock/NimBLE-Arduino/src/nimble/nimble/host/src/ble_gap.c:1051
 (inlined by) ble_gap_rx_adv_report at /home/dam/dm/esphome-configs/.esphome/build/iot-door-lock/.piolibdeps/iot-door-lock/NimBLE-Arduino/src/nimble/nimble/host/src/ble_gap.c:1579
WARNING Decoded 0x401800c9: ble_hs_hci_evt_le_adv_rpt at /home/dam/dm/esphome-configs/.esphome/build/iot-door-lock/.piolibdeps/iot-door-lock/NimBLE-Arduino/src/nimble/nimble/host/src/ble_hs_hci_evt.c:517 (discriminator 3)
WARNING Decoded 0x4017ff75: ble_hs_hci_evt_le_meta at /home/dam/dm/esphome-configs/.esphome/build/iot-door-lock/.piolibdeps/iot-door-lock/NimBLE-Arduino/src/nimble/nimble/host/src/ble_hs_hci_evt.c:316
WARNING Decoded 0x40180391: ble_hs_hci_evt_process at /home/dam/dm/esphome-configs/.esphome/build/iot-door-lock/.piolibdeps/iot-door-lock/NimBLE-Arduino/src/nimble/nimble/host/src/ble_hs_hci_evt.c:879
WARNING Decoded 0x4017ebf9: ble_hs_event_rx_hci_ev at /home/dam/dm/esphome-configs/.esphome/build/iot-door-lock/.piolibdeps/iot-door-lock/NimBLE-Arduino/src/nimble/nimble/host/src/ble_hs.c:548
WARNING Decoded 0x4008fb8e: ble_npl_event_run at /home/dam/dm/esphome-configs/.esphome/build/iot-door-lock/.piolibdeps/iot-door-lock/NimBLE-Arduino/src/nimble/porting/npl/freertos/include/nimble/nimble_npl_os.h:526
 (inlined by) nimble_port_run at /home/dam/dm/esphome-configs/.esphome/build/iot-door-lock/.piolibdeps/iot-door-lock/NimBLE-Arduino/src/nimble/porting/nimble/src/nimble_port.c:269
WARNING Decoded 0x40176b9a: NimBLEDevice::host_task(void*) at /home/dam/dm/esphome-configs/.esphome/build/iot-door-lock/.piolibdeps/iot-door-lock/NimBLE-Arduino/src/NimBLEDevice.cpp:836
```

Looking at the code, I thought this was probably due to one of the pointers (the handler, or the `status_update_` pointer) getting invalid at some point and the crash leaving the bluetooth stack in an inoperable state. 

This code replaces the lock instance and the handler with member variables and configures event handling in the constructor so that no pointers are needed anymore (and so none can get invalid).

This seems to fix issue #26 for me but I still haven't used it a lot. But the crash that I dumped here is fixed for sure.