### PR TITLE
Increase speed and reliability by orders of magnitude

### DIFF
--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -200,7 +200,7 @@ void NukiLockComponent::update() {
             // Terminate stale Bluetooth connections
             this->nukiLock_.updateConnectionState();
 
-            if (millis() - lastCommandExecutedTime_ < COMMANDS_COOLDOWN_MILLIS) {
+            if (millis() - lastCommandExecutedTime_ < ACTIONS_COOLDOWN_MILLIS) {
                 // Let the lock terminate the previous command
                 ESP_LOGD(TAG, "Too early for action, skipping...");
             } else {
@@ -234,7 +234,7 @@ void NukiLockComponent::update() {
             // Terminate stale Bluetooth connections
             this->nukiLock_.updateConnectionState();
 
-            if (millis() - lastCommandExecutedTime_ < COMMANDS_COOLDOWN_MILLIS) {
+            if (millis() - lastCommandExecutedTime_ < UPDATES_COOLDOWN_MILLIS) {
                 // Let the lock terminate the previous command
                 ESP_LOGD(TAG, "Too early for status update, skipping...");
             } else {
@@ -247,7 +247,7 @@ void NukiLockComponent::update() {
             // Terminate stale Bluetooth connections
             this->nukiLock_.updateConnectionState();
 
-            if (millis() - lastCommandExecutedTime_ < COMMANDS_COOLDOWN_MILLIS) {
+            if (millis() - lastCommandExecutedTime_ < UPDATES_COOLDOWN_MILLIS) {
                 // Let the lock terminate the previous command
                 ESP_LOGD(TAG, "Too early for config update, skipping...");
             } else {

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -187,6 +187,9 @@ void NukiLockComponent::update() {
         // Execute (all) actions first, then status updates, then config updates.
         // Only one command (action, status, or config) is executed per update() call.
         if (this->actionAttempts_ > 0) {
+            // Terminate stale Bluetooth connections
+            this->nukiLock_.updateConnectionState();
+
             if (millis() - lastCommandExecutedTime_ < COMMANDS_COOLDOWN_MILLIS) {
                 // Let the lock terminate the previous command
                 ESP_LOGD(TAG, "Too early for action, skipping...");
@@ -218,6 +221,9 @@ void NukiLockComponent::update() {
             }
 
         } else if (this->status_update_) {
+            // Terminate stale Bluetooth connections
+            this->nukiLock_.updateConnectionState();
+
             if (millis() - lastCommandExecutedTime_ < COMMANDS_COOLDOWN_MILLIS) {
                 // Let the lock terminate the previous command
                 ESP_LOGD(TAG, "Too early for status update, skipping...");
@@ -228,6 +234,9 @@ void NukiLockComponent::update() {
             }
 
         } else if (this->config_update_) {
+            // Terminate stale Bluetooth connections
+            this->nukiLock_.updateConnectionState();
+
             if (millis() - lastCommandExecutedTime_ < COMMANDS_COOLDOWN_MILLIS) {
                 // Let the lock terminate the previous command
                 ESP_LOGD(TAG, "Too early for config update, skipping...");

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -274,7 +274,7 @@ void NukiLockComponent::control(const lock::LockCall &call) {
 
     lock::LockState state = *call.get_state();
 
-    switch(state){
+    switch(state) {
         case lock::LOCK_STATE_LOCKED:
             this->actionAttempts_ = MAX_ACTION_ATTEMPTS;
             this->lockAction_ = NukiLock::LockAction::Lock;
@@ -284,11 +284,11 @@ void NukiLockComponent::control(const lock::LockCall &call) {
             this->actionAttempts_ = MAX_ACTION_ATTEMPTS;
             this->lockAction_ = NukiLock::LockAction::Unlock;
 
-            if(this->open_latch_){
+            if(this->open_latch_) {
                 this->lockAction_ = NukiLock::LockAction::Unlatch;
             }
 
-            if(this->lock_n_go_){
+            if(this->lock_n_go_) {
                 this->lockAction_ = NukiLock::LockAction::LockNgo;
             }
 
@@ -307,7 +307,7 @@ void NukiLockComponent::control(const lock::LockCall &call) {
     ESP_LOGI(TAG, "New lock action received: %s (%d)", lockActionAsString, this->lockAction_);
 }
 
-void NukiLockComponent::lock_n_go(){
+void NukiLockComponent::lock_n_go() {
     this->lock_n_go_ = true;
     this->unlock();
 }
@@ -346,7 +346,7 @@ void NukiLockComponent::add_keypad_entry(std::string name, int code) {
         ESP_LOGE(TAG, "add_keypad_entry invalid parameters");
         return;
     }
-        
+
     NukiLock::NewKeypadEntry entry;
     memset(&entry, 0, sizeof(entry));
     size_t nameLen = name.length();
@@ -393,7 +393,7 @@ void NukiLockComponent::delete_keypad_entry(int id) {
         ESP_LOGE(TAG, "keypad is not paired to Nuki");
         return;
     }
-        
+
     if (! valid_keypad_id(id)) {
         ESP_LOGE(TAG, "delete_keypad_entry invalid parameters");
         return;
@@ -416,7 +416,7 @@ void NukiLockComponent::print_keypad_entries() {
 
     Nuki::CmdResult result = this->nukiLock_.retrieveKeypadEntries(0, 0xffff);
     if(result == Nuki::CmdResult::Success) {
-        ESP_LOGI(TAG, "retrieveKeypadEntries sucess"); 
+        ESP_LOGI(TAG, "retrieveKeypadEntries sucess");
         std::list<NukiLock::KeypadEntry> entries;
         this->nukiLock_.getKeypadEntries(&entries);
 
@@ -435,7 +435,7 @@ void NukiLockComponent::print_keypad_entries() {
 }
 
 
-void NukiLockComponent::dump_config(){
+void NukiLockComponent::dump_config() {
     LOG_LOCK(TAG, "Nuki Lock", this);
     LOG_BINARY_SENSOR(TAG, "Is Connected", this->is_connected_);
     LOG_BINARY_SENSOR(TAG, "Is Paired", this->is_paired_);

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -193,15 +193,15 @@ void NukiLockComponent::update() {
     this->scanner_.update();
     delay(20);
 
+    // Terminate stale Bluetooth connections
+    this->nukiLock_.updateConnectionState();
+
     if (this->nukiLock_.isPairedWithLock()) {
         this->is_paired_->publish_state(true);
 
         // Execute (all) actions first, then status updates, then config updates.
         // Only one command (action, status, or config) is executed per update() call.
         if (this->actionAttempts_ > 0) {
-            // Terminate stale Bluetooth connections
-            this->nukiLock_.updateConnectionState();
-
             if (millis() - lastCommandExecutedTime_ < ACTIONS_COOLDOWN_MILLIS) {
                 // Let the lock terminate the previous command
                 ESP_LOGD(TAG, "Too early for action, skipping...");
@@ -233,9 +233,6 @@ void NukiLockComponent::update() {
             }
 
         } else if (this->status_update_) {
-            // Terminate stale Bluetooth connections
-            this->nukiLock_.updateConnectionState();
-
             if (millis() - lastCommandExecutedTime_ < UPDATES_COOLDOWN_MILLIS) {
                 // Let the lock terminate the previous command
                 ESP_LOGD(TAG, "Too early for status update, skipping...");
@@ -246,9 +243,6 @@ void NukiLockComponent::update() {
             }
 
         } else if (this->config_update_) {
-            // Terminate stale Bluetooth connections
-            this->nukiLock_.updateConnectionState();
-
             if (millis() - lastCommandExecutedTime_ < UPDATES_COOLDOWN_MILLIS) {
                 // Let the lock terminate the previous command
                 ESP_LOGD(TAG, "Too early for config update, skipping...");

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -156,7 +156,8 @@ void NukiLockComponent::setup() {
     this->traits.set_supported_states(std::set<lock::LockState> {lock::LOCK_STATE_NONE, lock::LOCK_STATE_LOCKED,
                                                                  lock::LOCK_STATE_UNLOCKED, lock::LOCK_STATE_JAMMED,
                                                                  lock::LOCK_STATE_LOCKING, lock::LOCK_STATE_UNLOCKING});
-    this->scanner_.initialize();
+    this->scanner_.initialize("ESPHomeNuki");
+    this->scanner_.setScanDuration(10);
     this->nukiLock_.registerBleScanner(&this->scanner_);
     this->nukiLock_.initialize();
     this->nukiLock_.setConnectTimeout(BLE_CONNECT_TIMEOUT_SEC);
@@ -190,6 +191,7 @@ void NukiLockComponent::update() {
 
     // Check for new advertisements
     this->scanner_.update();
+    delay(20);
 
     if (this->nukiLock_.isPairedWithLock()) {
         this->is_paired_->publish_state(true);

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -20,6 +20,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
     static const uint8_t BLE_CONNECT_TIMEOUT_SEC = 3;
     static const uint8_t BLE_CONNECT_TIMEOUT_RETRIES = 1;
     static const uint8_t MAX_ACTION_ATTEMPTS = 5;
+    static const uint8_t MAX_TOLERATED_UPDATES_ERRORS = 5;
     static const uint32_t ACTIONS_COOLDOWN_MILLIS = 3000;
     static const uint32_t UPDATES_COOLDOWN_MILLIS = 1000;
 
@@ -74,6 +75,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
         NukiLock::KeyTurnerState retrievedKeyTurnerState_;
         uint32_t lastCommandExecutedTime_ = 0;
         uint8_t actionAttempts_ = 0;
+        uint32_t statusUpdateConsecutiveErrors_ = 0;
         NukiLock::LockAction lockAction_;
         bool status_update_;
         bool config_update_;

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -26,8 +26,8 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
         const uint32_t deviceId_ = 2020002;
         const std::string deviceName_ = "Nuki ESPHome";
 
-        explicit NukiLockComponent() : Lock(), unpair_(false), 
-                                       open_latch_(false), lock_n_go_(false), 
+        explicit NukiLockComponent() : Lock(), unpair_(false),
+                                       open_latch_(false), lock_n_go_(false),
                                        keypad_paired_(false),
                                        nukiLock_(deviceName_, deviceId_) {
                 this->traits.set_supports_open(true);
@@ -82,7 +82,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
 
     private:
         NukiLock::NukiLock nukiLock_;
-        
+
         void lock_n_go();
         void print_keypad_entries();
         void add_keypad_entry(std::string name, int code);

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -21,8 +21,8 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
     static const uint8_t BLE_CONNECT_TIMEOUT_RETRIES = 1;
     static const uint8_t MAX_ACTION_ATTEMPTS = 5;
     static const uint8_t MAX_TOLERATED_UPDATES_ERRORS = 5;
-    static const uint32_t ACTIONS_COOLDOWN_MILLIS = 3000;
-    static const uint32_t UPDATES_COOLDOWN_MILLIS = 1000;
+    static const uint32_t COOLDOWN_COMMANDS_MILLIS = 1000;
+    static const uint32_t COOLDOWN_COMMANDS_EXTENDED_MILLIS = 3000;
 
     public:
         const uint32_t deviceId_ = 2020002;
@@ -74,6 +74,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
         BleScanner::Scanner scanner_;
         NukiLock::KeyTurnerState retrievedKeyTurnerState_;
         uint32_t lastCommandExecutedTime_ = 0;
+        uint32_t command_cooldown_millis = 0;
         uint8_t actionAttempts_ = 0;
         uint32_t statusUpdateConsecutiveErrors_ = 0;
         NukiLock::LockAction lockAction_;

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -20,7 +20,8 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
     static const uint8_t BLE_CONNECT_TIMEOUT_SEC = 3;
     static const uint8_t BLE_CONNECT_TIMEOUT_RETRIES = 1;
     static const uint8_t MAX_ACTION_ATTEMPTS = 5;
-    static const uint32_t COMMANDS_COOLDOWN_MILLIS = 3000;
+    static const uint32_t ACTIONS_COOLDOWN_MILLIS = 3000;
+    static const uint32_t UPDATES_COOLDOWN_MILLIS = 1000;
 
     public:
         const uint32_t deviceId_ = 2020002;

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -20,6 +20,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
     static const uint8_t BLE_CONNECT_TIMEOUT_SEC = 3;
     static const uint8_t BLE_CONNECT_TIMEOUT_RETRIES = 1;
     static const uint8_t MAX_ACTION_ATTEMPTS = 5;
+    static const uint32_t COMMANDS_COOLDOWN_MILLIS = 3000;
 
     public:
         const uint32_t deviceId_ = 2020002;
@@ -70,6 +71,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
 
         BleScanner::Scanner scanner_;
         NukiLock::KeyTurnerState retrievedKeyTurnerState_;
+        uint32_t lastCommandExecutedTime_ = 0;
         uint8_t actionAttempts_ = 0;
         NukiLock::LockAction lockAction_;
         bool status_update_;

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -19,6 +19,7 @@ static const char *TAG = "nukilock.lock";
 class NukiLockComponent : public lock::Lock, public PollingComponent, public api::CustomAPIDevice, public Nuki::SmartlockEventHandler {
     static const uint8_t BLE_CONNECT_TIMEOUT_SEC = 3;
     static const uint8_t BLE_CONNECT_TIMEOUT_RETRIES = 1;
+    static const uint8_t MAX_ACTION_ATTEMPTS = 5;
 
     public:
         const uint32_t deviceId_ = 2020002;
@@ -56,6 +57,8 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
     protected:
         void control(const lock::LockCall &call) override;
         void update_status();
+        void update_config();
+        bool executeLockAction(NukiLock::LockAction lockAction);
         void open_latch() override { this->open_latch_ = true; unlock();}
 
         binary_sensor::BinarySensor *is_connected_{nullptr};
@@ -67,7 +70,10 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
 
         BleScanner::Scanner scanner_;
         NukiLock::KeyTurnerState retrievedKeyTurnerState_;
+        uint8_t actionAttempts_ = 0;
+        NukiLock::LockAction lockAction_;
         bool status_update_;
+        bool config_update_;
         bool unpair_;
         bool open_latch_;
         bool lock_n_go_;


### PR DESCRIPTION
I created this PR mainly to address these issues: #26, #16, and I-Connect/NukiBleEsp32#37.

It's a bit of code, but I made sure that every commit is self-contained and commented on.
I suggest reviewing this PR by going commit by commit, and not only the final result.

Features:
- Implement a retry mechanism
- The lock is now much faster to execute commands and retrieve results
- It works even when sending fast-paced commands
- It correctly reports the locking and unlocking states of the lock more reliably
- Actions and status updates are now correctly prioritized and paced
- Stale Bluetooth connections are now terminated without having to wait for the lock to forcibly close the connection after 20 seconds (see [these lines](https://github.com/I-Connect/NukiBleEsp32/blob/707b327f1b84ab50fbb15b16991a9ea7fc10641d/src/NukiBle.h#L59-L67))

For best results, I recommend decreasing NukiBleEsp32 `CMD_TIMEOUT` as I did in this commit: https://github.com/zanna-37/NukiBleEsp32/commit/1677425e9e6bd484e1abb0669b7d9d23259ecb23

~I'm marking this PR as a draft in order to have some days in which I will further test the code.~
I tested this for 3 weeks and it's working properly.
Any opinion is welcome.
And thanks for this amazing repo!