### PR TITLE
Add new library for newer ESPHome

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Add the following to the ESPHome yaml file:
 esphome:
   libraries:
   - Preferences
+  - https://github.com/h2zero/NimBLE-Arduino
   - https://github.com/vinmenn/Crc16.git
   - https://github.com/uriyacovy/NukiBleEsp32
 


### PR DESCRIPTION
Fixes https://github.com/uriyacovy/ESPHome_nuki_lock/issues/44

In ESPHome 2024.5 something has changed (https://github.com/uriyacovy/ESPHome_nuki_lock/issues/44#issuecomment-2118838202) and now we need a new library.