### PR TITLE
Feature: Several Basic and Advanced Settings, Event logs, Last Unlock User

### DIFF
--- a/.github/example-project-dev.yaml
+++ b/.github/example-project-dev.yaml
@@ -6,7 +6,7 @@ esphome:
     - Preferences
     - https://github.com/h2zero/NimBLE-Arduino#1.4.0
     - Crc16
-    - https://github.com/uriyacovy/NukiBleEsp32#dev
+    - https://github.com/I-Connect/NukiBleEsp32
 
 esp32:
   framework:

--- a/.github/example-project-dev.yaml
+++ b/.github/example-project-dev.yaml
@@ -6,7 +6,7 @@ esphome:
     - Preferences
     - https://github.com/h2zero/NimBLE-Arduino#1.4.0
     - Crc16
-    - https://github.com/I-Connect/NukiBleEsp32
+    - https://github.com/uriyacovy/NukiBleEsp32#dev
 
 esp32:
   framework:

--- a/.github/example-project-main.yaml
+++ b/.github/example-project-main.yaml
@@ -6,7 +6,7 @@ esphome:
     - Preferences
     - https://github.com/h2zero/NimBLE-Arduino#1.4.0
     - Crc16
-    - https://github.com/uriyacovy/NukiBleEsp32
+    - https://github.com/I-Connect/NukiBleEsp32#93e7da927171c8973b7ef857c7fa644c174ed47d
 
 esp32:
   framework:

--- a/.github/example-project-main.yaml
+++ b/.github/example-project-main.yaml
@@ -6,7 +6,7 @@ esphome:
     - Preferences
     - https://github.com/h2zero/NimBLE-Arduino#1.4.0
     - Crc16
-    - https://github.com/I-Connect/NukiBleEsp32
+    - https://github.com/uriyacovy/NukiBleEsp32
 
 esp32:
   framework:

--- a/.github/example-project-main.yaml
+++ b/.github/example-project-main.yaml
@@ -6,7 +6,7 @@ esphome:
     - Preferences
     - https://github.com/h2zero/NimBLE-Arduino#1.4.0
     - Crc16
-    - https://github.com/uriyacovy/NukiBleEsp32
+    - https://github.com/I-Connect/NukiBleEsp32
 
 esp32:
   framework:

--- a/.github/shared-config.yaml
+++ b/.github/shared-config.yaml
@@ -72,6 +72,12 @@ lock:
       name: "Nuki Single Button Press Action"
     double_buton_press_action:
       name: "Nuki Double Button Press Action"
+    fob_action_1:
+      name: "Nuki Fob Action 1"
+    fob_action_2:
+      name: "Nuki Fob Action 2"
+    fob_action_3:
+      name: "Nuki Fob Action 3"
 
     security_pin: 1234
     pairing_mode_timeout: 300s

--- a/.github/shared-config.yaml
+++ b/.github/shared-config.yaml
@@ -32,7 +32,7 @@ lock:
     door_sensor_state:
       name: "Nuki Door Sensor: State"
     unpair:
-      name: "Nuki Unpair"
+      name: "Nuki Unpair Device"
     pairing_mode:
       name: "Nuki Pairing Mode"
     auto_unlatch:

--- a/.github/shared-config.yaml
+++ b/.github/shared-config.yaml
@@ -19,20 +19,27 @@ external_components:
 lock:
   - platform: nuki_lock
     name: Nuki Lock
+
     is_connected:
       name: "Nuki Connected"
     is_paired:
       name: "Nuki Paired"
     battery_critical:
       name: "Nuki Battery Critical"
-    battery_level:
-      name: "Nuki Battery Level"
     door_sensor:
       name: "Nuki Door Sensor"
+
+    battery_level:
+      name: "Nuki Battery Level"
+    
     door_sensor_state:
       name: "Nuki Door Sensor: State"
+    last_unlock_user:
+      name: "Nuki Last Unlock User"
+
     unpair:
       name: "Nuki Unpair Device"
+      
     pairing_mode:
       name: "Nuki Pairing Mode"
     auto_unlatch:
@@ -41,8 +48,6 @@ lock:
       name: "Nuki Button: Locking operations"
     led_enabled:
       name: "Nuki LED Signal"
-    led_brightness:
-      name: "Nuki LED Brightness"
     night_mode_enabled:
       name: "Nuki Night Mode"
     night_mode_auto_lock_enabled:
@@ -59,12 +64,19 @@ lock:
       name: "Nuki Auto Lock: Immediately"
     auto_update_enabled:
       name: "Nuki Automatic Updates"
+
+    led_brightness:
+      name: "Nuki LED Brightness"
+
     single_buton_press_action:
       name: "Nuki Single Button Press Action"
     double_buton_press_action:
       name: "Nuki Double Button Press Action"
+
     security_pin: 1234
     pairing_mode_timeout: 300s
+    event: "nuki"
+
     on_pairing_mode_on_action:
       - lambda: ESP_LOGI("nuki_lock", "Pairing mode turned on");
     on_pairing_mode_off_action:

--- a/.github/shared-config.yaml
+++ b/.github/shared-config.yaml
@@ -18,16 +18,36 @@ external_components:
 
 lock:
   - platform: nuki_lock
-    name: My Nuki Lock
+    name: Nuki Lock
+    is_connected:
+      name: "Nuki Connected"
     is_paired:
       name: "Nuki Paired"
     battery_critical:
       name: "Nuki Battery Critical"
     battery_level:
       name: "Nuki Battery Level"
-    is_connected:
-      name: "Nuki Connected"
     door_sensor:
       name: "Nuki Door Sensor"
     door_sensor_state:
       name: "Nuki Door Sensor State"
+    unpair:
+      name: "Nuki Unpair"
+    pairing_mode:
+      name: "Nuki Pairing Mode"
+    auto_unlatch:
+      name: "Nuki Auto unlatch"
+    button_enabled:
+      name: "Nuki Button enabled"
+    led_enabled:
+      name: "Nuki LED enabled"
+    led_brightness:
+      name: "Nuki LED brightness"
+    security_pin: 1234
+    pairing_mode_timeout: 300s
+    on_pairing_mode_on_action:
+      - lambda: ESP_LOGI("nuki_lock", "Pairing mode turned on");
+    on_pairing_mode_off_action:
+      - lambda: ESP_LOGI("nuki_lock", "Pairing mode turned off");
+    on_paired_action:
+      - lambda: ESP_LOGI("nuki_lock", "Paired sucessfuly");

--- a/.github/shared-config.yaml
+++ b/.github/shared-config.yaml
@@ -30,7 +30,7 @@ lock:
     door_sensor:
       name: "Nuki Door Sensor"
     door_sensor_state:
-      name: "Nuki Door Sensor State"
+      name: "Nuki Door Sensor: State"
     unpair:
       name: "Nuki Unpair"
     pairing_mode:
@@ -38,11 +38,31 @@ lock:
     auto_unlatch:
       name: "Nuki Auto unlatch"
     button_enabled:
-      name: "Nuki Button enabled"
+      name: "Nuki Button: Locking operations"
     led_enabled:
-      name: "Nuki LED enabled"
+      name: "Nuki LED Signal"
     led_brightness:
-      name: "Nuki LED brightness"
+      name: "Nuki LED Brightness"
+    night_mode_enabled:
+      name: "Nuki Night Mode"
+    night_mode_auto_lock_enabled:
+      name: "Nuki Night Mode: Auto Lock"
+    night_mode_auto_unlock_disabled:
+      name: "Nuki Night Mode: Reject Auto Unlock"
+    night_mode_immediate_lock_on_start_enabled:
+      name: "Nuki Night Mode: Lock at Start Time"
+    auto_lock_enabled:
+      name: "Nuki Auto Lock"
+    auto_unlock_disabled:
+      name: "Nuki Auto Unlock: Disable"
+    immediate_auto_lock_enabled:
+      name: "Nuki Auto Lock: Immediately"
+    auto_update_enabled:
+      name: "Nuki Automatic Updates"
+    single_buton_press_action:
+      name: "Nuki Single Button Press Action"
+    double_buton_press_action:
+      name: "Nuki Double Button Press Action"
     security_pin: 1234
     pairing_mode_timeout: 300s
     on_pairing_mode_on_action:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ lock:
       name: "Nuki Unpair"
     pairing_mode:
       name: "Nuki Pairing Mode"
+    auto_unlatch:
+      name: "Nuki Auto unlatch"
     button_enabled:
       name: "Nuki Button enabled"
     led_enabled:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ lock:
   # Optional: Settings
     security_pin: 1234
     pairing_mode_timeout: 300s
+    event: "nuki"
 
   # Optional: Callbacks
     on_pairing_mode_on_action:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This module builds an ESPHome lock platform for Nuki Smartlock (nuki_lock) that 
 - Binary Sensor: Door Sensor
 - Text Sensor: Door Sensor State
 - Switch: Pairing Mode
+- Switch: Button Enabled
+- Switch: LED Enabled
+- Number: LED Brightness
 - Button: Unpair
 
 The lock entity is updated whenever the look changes state (via Nuki App, HA, or manually) using Nuki BT advertisement mechanism.
@@ -60,6 +63,12 @@ lock:
       name: "Nuki Unpair"
     pairing_mode:
       name: "Nuki Pairing Mode"
+    button_enabled:
+      name: "Nuki Button enabled"
+    led_enabled:
+      name: "Nuki LED enabled"
+    led_brightness:
+      name: "Nuki LED brightness"
 
   # Optional: Settings
     security_pin: 1234

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ esphome:
   - Preferences
   - https://github.com/h2zero/NimBLE-Arduino#1.4.0
   - Crc16
-  - https://github.com/uriyacovy/NukiBleEsp32
+  - https://github.com/I-Connect/NukiBleEsp32#93e7da927171c8973b7ef857c7fa644c174ed47d
 
 external_components:
   - source: github://uriyacovy/ESPHome_nuki_lock

--- a/README.md
+++ b/README.md
@@ -81,15 +81,15 @@ lock:
       name: "Nuki Automatic Updates"
       
     single_buton_press_action:
-      name: "Nuki Single Button Press Action"
+      name: "Nuki Button: Single Press Action"
     double_buton_press_action:
-      name: "Nuki Double Button Press Action"
+      name: "Nuki Button: Double Press Action"
     fob_action_1:
-      name: "Nuki Fob Action 1"
+      name: "Nuki Fob: Action 1"
     fob_action_2:
-      name: "Nuki Fob Action 2"
+      name: "Nuki Fob: Action 2"
     fob_action_3:
-      name: "Nuki Fob Action 3"
+      name: "Nuki Fob: Action 3"
 
     unpair:
       name: "Nuki Unpair Device"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESPHome Nuki Lock Component (ESP32) [![Build Component](https://github.com/uriyacovy/ESPHome_nuki_lock/actions/workflows/build.yaml/badge.svg)](https://github.com/uriyacovy/ESPHome_nuki_lock/actions/workflows/build.yaml)
 
-This module builds an ESPHome lock platform for Nuki Smartlocks (nuki_lock) that creates [23 entities](#entites) in Home Assistant.
+This module builds an ESPHome lock platform for Nuki Smartlocks (nuki_lock) that creates [24 entities](#entites) in Home Assistant.
 
 The lock entity is updated whenever the look changes state (via Nuki App, HA, or manually) using the Nuki BLE advertisement mechanism.
 
@@ -46,6 +46,8 @@ lock:
       name: "Nuki Door Sensor"
     door_sensor_state:
       name: "Nuki Door Sensor: State"
+    last_unlock_user:
+      name: "Nuki Last Unlock User"
     unpair:
       name: "Nuki Unpair Device"
     pairing_mode:
@@ -157,6 +159,7 @@ on_paired_action:
 
 **Text Sensor:**  
 - Door Sensor State
+- Last Unlock User
 
 **Switch:**  
 - Pairing Mode

--- a/README.md
+++ b/README.md
@@ -1,21 +1,8 @@
-# Nuki Lock for ESPHome (ESP32)
-[![Build Component](https://github.com/uriyacovy/ESPHome_nuki_lock/actions/workflows/build.yaml/badge.svg)](https://github.com/uriyacovy/ESPHome_nuki_lock/actions/workflows/build.yaml)
+# ESPHome Nuki Lock Component (ESP32) [![Build Component](https://github.com/uriyacovy/ESPHome_nuki_lock/actions/workflows/build.yaml/badge.svg)](https://github.com/uriyacovy/ESPHome_nuki_lock/actions/workflows/build.yaml)
 
-This module builds an ESPHome lock platform for Nuki Smartlock (nuki_lock) that creates 9 new entities in Home Assistant:
-- Lock 
-- Binary Sensor: Is Paired
-- Binary Sensor: Is Connected
-- Binary Sensor: Critical Battery 
-- Sensor: Battery Level
-- Binary Sensor: Door Sensor
-- Text Sensor: Door Sensor State
-- Switch: Pairing Mode
-- Switch: Button Enabled
-- Switch: LED Enabled
-- Number: LED Brightness
-- Button: Unpair
+This module builds an ESPHome lock platform for Nuki Smartlocks (nuki_lock) that creates [23 entities](#entites) in Home Assistant.
 
-The lock entity is updated whenever the look changes state (via Nuki App, HA, or manually) using Nuki BT advertisement mechanism.
+The lock entity is updated whenever the look changes state (via Nuki App, HA, or manually) using the Nuki BLE advertisement mechanism.
 
 ![dashboard](./docs/nuki_dashboard.png)
 
@@ -60,7 +47,7 @@ lock:
     door_sensor_state:
       name: "Nuki Door Sensor: State"
     unpair:
-      name: "Nuki Unpair"
+      name: "Nuki Unpair Device"
     pairing_mode:
       name: "Nuki Pairing Mode"
     auto_unlatch:
@@ -137,7 +124,7 @@ on_...:
 ```
 
 ### Action: Unpair
-You can use this action to unpair your Nuki: 
+You can use this action to unpair your Nuki Smartlock: 
 ```yaml
 on_...:
   - nuki_lock.unpair:
@@ -153,6 +140,46 @@ on_pairing_mode_off_action:
 on_paired_action:
   - lambda: ESP_LOGI("nuki_lock", "Paired sucessfuly");
 ```
+
+## Entites
+
+**Lock:**  
+- Lock
+
+**Binary Sensor:**  
+- Is Paired
+- Is Connected
+- Critical Battery 
+- Door Sensor
+
+**Sensor:**
+- Battery Level
+
+**Text Sensor:**  
+- Door Sensor State
+
+**Switch:**  
+- Pairing Mode
+- Button Enabled
+- LED Enabled
+- Night Mode
+- Night Mode: Auto Lock
+- Night Mode: Reject Auto Unlock
+- Night Mode: Lock at Start Time
+- Auto Lock
+- Auto Unlock: Disable
+- Auto Lock: Immediately
+- Automatic Updates
+
+**Select:**  
+- Single Button Press Action
+- Double Button Press Action
+
+**Number:**  
+- LED Brightness
+
+**Button:**  
+- Unpair Device
 
 ## Dependencies
 The module depends on the work done by [I-Connect](https://github.com/I-Connect) with [NukiBleEsp32](https://github.com/I-Connect/NukiBleEsp32).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This module builds an ESPHome lock platform for Nuki Smartlocks (nuki_lock) that
 
 The lock entity is updated whenever the look changes state (via Nuki App, HA, or manually) using the Nuki BLE advertisement mechanism.
 
-![dashboard](./docs/nuki_dashboard.png)
+![some dashboard entites](./docs/nuki_dashboard.png)
 
 
 ## How to use
@@ -158,9 +158,9 @@ on_paired_action:
 ```
 
 ### Events
-By default this component sends the event logs as events to Home Assistant.
+By default this component sends the Nuki logs as events to Home Assistant.
 You can use them in automations. If you want to disable events, set the `event` property in your yaml to `none`.
-If you want to check the log events, go to the Homne Assistant Developer tools -> Events and listen for `esphome.nuki` events.
+If you want to check the log events, go to the Home Assistant Developer tools -> Events and listen for `esphome.nuki` events.
 ```yaml
 event_type: esphome.nuki
 data:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESPHome Nuki Lock Component (ESP32) [![Build Component](https://github.com/uriyacovy/ESPHome_nuki_lock/actions/workflows/build.yaml/badge.svg)](https://github.com/uriyacovy/ESPHome_nuki_lock/actions/workflows/build.yaml)
 
-This module builds an ESPHome lock platform for Nuki Smartlocks (nuki_lock) that creates [24 entities](#entites) in Home Assistant.
+This module builds an ESPHome lock platform for Nuki Smartlocks (nuki_lock) that creates [24 entities](#entities) in Home Assistant.
 
 The lock entity is updated whenever the look changes state (via Nuki App, HA, or manually) using the Nuki BLE advertisement mechanism.
 
@@ -16,7 +16,7 @@ esphome:
   - Preferences
   - https://github.com/h2zero/NimBLE-Arduino#1.4.0
   - Crc16
-  - https://github.com/I-Connect/NukiBleEsp32#93e7da927171c8973b7ef857c7fa644c174ed47d
+  - https://github.com/uriyacovy/NukiBleEsp32
 
 external_components:
   - source: github://uriyacovy/ESPHome_nuki_lock
@@ -158,8 +158,9 @@ on_paired_action:
 ```
 
 ### Events
-By default this component sends auth eventlog events to Home Assistant.
+By default this component sends the event logs as events to Home Assistant.
 You can use them in automations. If you want to disable events, set the `event` property in your yaml to `none`.
+If you want to check the log events, go to the Homne Assistant Developer tools -> Events and listen for `esphome.nuki` events.
 ```yaml
 event_type: esphome.nuki
 data:
@@ -185,7 +186,7 @@ context:
   user_id: null
 ```
 
-## Entites
+## Entities
 
 **Lock:**  
 - Lock
@@ -219,6 +220,9 @@ context:
 **Select:**  
 - Single Button Press Action
 - Double Button Press Action
+- Fob Action 1
+- Fob Action 2
+- Fob Action 3
 
 **Number:**  
 - LED Brightness

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ lock:
     door_sensor:
       name: "Nuki Door Sensor"
     door_sensor_state:
-      name: "Nuki Door Sensor State"
+      name: "Nuki Door Sensor: State"
     unpair:
       name: "Nuki Unpair"
     pairing_mode:
@@ -66,11 +66,31 @@ lock:
     auto_unlatch:
       name: "Nuki Auto unlatch"
     button_enabled:
-      name: "Nuki Button enabled"
+      name: "Nuki Button: Locking operations"
     led_enabled:
-      name: "Nuki LED enabled"
+      name: "Nuki LED Signal"
     led_brightness:
-      name: "Nuki LED brightness"
+      name: "Nuki LED Brightness"
+    night_mode_enabled:
+      name: "Nuki Night Mode"
+    night_mode_auto_lock_enabled:
+      name: "Nuki Night Mode: Auto Lock"
+    night_mode_auto_unlock_disabled:
+      name: "Nuki Night Mode: Reject Auto Unlock"
+    night_mode_immediate_lock_on_start_enabled:
+      name: "Nuki Night Mode: Lock at Start Time"
+    auto_lock_enabled:
+      name: "Nuki Auto Lock"
+    auto_unlock_disabled:
+      name: "Nuki Auto Unlock: Disable"
+    immediate_auto_lock_enabled:
+      name: "Nuki Auto Lock: Immediately"
+    auto_update_enabled:
+      name: "Nuki Automatic Updates"
+    single_buton_press_action:
+      name: "Nuki Single Button Press Action"
+    double_buton_press_action:
+      name: "Nuki Double Button Press Action"
 
   # Optional: Settings
     security_pin: 1234

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ service: esphome.<NODE_NAME>_lock_n_go
 data: {}
 ```
 
-## Automation ##
-### Action: Pairing Mode ###
+## Automation
+### Action: Pairing Mode
 You can use this action to turn on/off the pairing mode: 
 ```yaml
 on_...:
@@ -142,6 +142,34 @@ on_pairing_mode_off_action:
   - lambda: ESP_LOGI("nuki_lock", "Pairing mode turned off");
 on_paired_action:
   - lambda: ESP_LOGI("nuki_lock", "Paired sucessfuly");
+```
+
+### Events
+By default this component sends auth eventlog events to Home Assistant.
+You can use them in automations. If you want to disable events, set the `event` property in your yaml to `none`.
+```yaml
+event_type: esphome.nuki
+data:
+  device_id: 373c62d6788cf81d322763235513310e
+  action: Unlatch
+  authorizationId: "3902896895"
+  authorizationName: Nuki ESPHome
+  completionStatus: success
+  index: "92"
+  timeDay: "25"
+  timeHour: "0"
+  timeMinute: "46"
+  timeMonth: "10"
+  timeSecond: "11"
+  timeYear: "2024"
+  trigger: system
+  type: LockAction
+origin: LOCAL
+time_fired: "2024-10-25T00:46:33.398284+00:00"
+context:
+  id: 01JB0J7AXPMS5DWHG188Y6XFCP
+  parent_id: null
+  user_id: null
 ```
 
 ## Entites

--- a/README.md
+++ b/README.md
@@ -40,16 +40,17 @@ lock:
   # Optional:
     battery_critical:
       name: "Nuki Battery Critical"
-    battery_level:
-      name: "Nuki Battery Level"
     door_sensor:
       name: "Nuki Door Sensor"
+
+    battery_level:
+      name: "Nuki Battery Level"
+
     door_sensor_state:
       name: "Nuki Door Sensor: State"
     last_unlock_user:
       name: "Nuki Last Unlock User"
-    unpair:
-      name: "Nuki Unpair Device"
+
     pairing_mode:
       name: "Nuki Pairing Mode"
     auto_unlatch:
@@ -58,8 +59,10 @@ lock:
       name: "Nuki Button: Locking operations"
     led_enabled:
       name: "Nuki LED Signal"
+
     led_brightness:
       name: "Nuki LED Brightness"
+
     night_mode_enabled:
       name: "Nuki Night Mode"
     night_mode_auto_lock_enabled:
@@ -76,10 +79,20 @@ lock:
       name: "Nuki Auto Lock: Immediately"
     auto_update_enabled:
       name: "Nuki Automatic Updates"
+      
     single_buton_press_action:
       name: "Nuki Single Button Press Action"
     double_buton_press_action:
       name: "Nuki Double Button Press Action"
+    fob_action_1:
+      name: "Nuki Fob Action 1"
+    fob_action_2:
+      name: "Nuki Fob Action 2"
+    fob_action_3:
+      name: "Nuki Fob Action 3"
+
+    unpair:
+      name: "Nuki Unpair Device"
 
   # Optional: Settings
     security_pin: 1234

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -29,6 +29,7 @@ CONF_DOOR_SENSOR_STATE = "door_sensor_state"
 CONF_UNPAIR_BUTTON = "unpair"
 
 CONF_PAIRING_MODE_SWITCH = "pairing_mode"
+CONF_AUTO_UNLATCH_ENABLED_SWITCH = "auto_unlatch_enabled"
 CONF_BUTTON_ENABLED_SWITCH = "button_enabled"
 CONF_LED_ENABLED_SWITCH = "led_enabled"
 
@@ -48,6 +49,7 @@ NukiLock = nuki_lock_ns.class_('NukiLockComponent', lock.Lock, switch.Switch, cg
 
 NukiLockUnpairButton = nuki_lock_ns.class_("NukiLockUnpairButton", button.Button, cg.Component)
 NukiLockPairingModeSwitch = nuki_lock_ns.class_("NukiLockPairingModeSwitch", switch.Switch, cg.Component)
+NukiLockAutoUnlatchEnabledSwitch = nuki_lock_ns.class_("NukiLockAutoUnlatchEnabledSwitch", switch.Switch, cg.Component)
 NukiLockButtonEnabledSwitch = nuki_lock_ns.class_("NukiLockButtonEnabledSwitch", switch.Switch, cg.Component)
 NukiLockLedEnabledSwitch = nuki_lock_ns.class_("NukiLockLedEnabledSwitch", switch.Switch, cg.Component)
 NukiLockLedBrightnessNumber = nuki_lock_ns.class_("NukiLockLedBrightnessNumber", number.Number, cg.Component)
@@ -97,6 +99,11 @@ CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend({
     ),
     cv.Optional(CONF_BUTTON_ENABLED_SWITCH): switch.switch_schema(
         NukiLockButtonEnabledSwitch,
+        device_class=DEVICE_CLASS_SWITCH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+    ),
+    cv.Optional(CONF_AUTO_UNLATCH_ENABLED_SWITCH): switch.switch_schema(
+        NukiLockAutoUnlatchEnabledSwitch,
         device_class=DEVICE_CLASS_SWITCH,
         entity_category=ENTITY_CATEGORY_CONFIG,
     ),
@@ -191,6 +198,11 @@ async def to_code(config):
         s = await switch.new_switch(button_enabled)
         await cg.register_parented(s, config[CONF_ID])
         cg.add(var.set_button_enabled_switch(s))
+
+    if auto_unlatch := config.get(CONF_AUTO_UNLATCH_ENABLED_SWITCH):
+        s = await switch.new_switch(auto_unlatch)
+        await cg.register_parented(s, config[CONF_ID])
+        cg.add(var.set_auto_unlatch_enabled_switch(s))
 
     if led_enabled := config.get(CONF_LED_ENABLED_SWITCH):
         s = await switch.new_switch(led_enabled)

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -32,8 +32,27 @@ CONF_PAIRING_MODE_SWITCH = "pairing_mode"
 CONF_AUTO_UNLATCH_SWITCH = "auto_unlatch"
 CONF_BUTTON_ENABLED_SWITCH = "button_enabled"
 CONF_LED_ENABLED_SWITCH = "led_enabled"
-
+CONF_NIGHT_MODE_ENABLED_SWITCH = "night_mode_enabled"
+CONF_NIGHT_MODE_AUTO_LOCK_ENABLED_SWITCH = "night_mode_auto_lock_enabled"
+CONF_NIGHT_MODE_AUTO_UNLOCK_DISABLED_SWITCH = "night_mode_auto_unlock_disabled"
+CONF_NIGHT_MODE_IMMEDIATE_LOCK_ON_START_ENABLED_SWITCH = "night_mode_immediate_lock_on_start_enabled"
+CONF_AUTO_LOCK_ENABLED_SWITCH = "auto_lock_enabled"
+CONF_AUTO_UNLOCK_DISABLED_SWITCH = "auto_unlock_disabled"
+CONF_IMMEDIATE_AUTO_LOCK_ENABLED_SWITCH = "immediate_auto_lock_enabled"
+CONF_AUTO_UPDATE_ENABLED_SWITCH = "auto_update_enabled"
+CONF_SINGLE_BUTTON_PRESS_ACTION_SELECT = "single_buton_press_action"
+CONF_DOUBLE_BUTTON_PRESS_ACTION_SELECT = "double_buton_press_action"
 CONF_LED_BRIGHTNESS_NUMBER = "led_brightness"
+
+CONF_BUTTON_PRESS_ACTION_SELECT_OPTIONS = [
+    "No Action",
+    "Intelligent",
+    "Unlock",
+    "Lock",
+    "Unlatch",
+    "Lock n Go",
+    "Show Status",
+]
 
 CONF_PAIRING_MODE_TIMEOUT = "pairing_mode_timeout"
 CONF_SECURITY_PIN = "security_pin"
@@ -52,7 +71,17 @@ NukiLockPairingModeSwitch = nuki_lock_ns.class_("NukiLockPairingModeSwitch", swi
 NukiLockAutoUnlatchEnabledSwitch = nuki_lock_ns.class_("NukiLockAutoUnlatchEnabledSwitch", switch.Switch, cg.Component)
 NukiLockButtonEnabledSwitch = nuki_lock_ns.class_("NukiLockButtonEnabledSwitch", switch.Switch, cg.Component)
 NukiLockLedEnabledSwitch = nuki_lock_ns.class_("NukiLockLedEnabledSwitch", switch.Switch, cg.Component)
+NukiLockNightModeEnabledSwitch = nuki_lock_ns.class_("NukiLockNightModeEnabledSwitch", switch.Switch, cg.Component)
+NukiLockNightModeAutoLockEnabledSwitch = nuki_lock_ns.class_("NukiLockNightModeAutoLockEnabledSwitch", switch.Switch, cg.Component)
+NukiLockNightModeAutoUnlockDisabledSwitch = nuki_lock_ns.class_("NukiLockNightModeAutoUnlockDisabledSwitch", switch.Switch, cg.Component)
+NukiLockNightModeImmediateLockOnStartEnabledSwitch = nuki_lock_ns.class_("NukiLockNightModeImmediateLockOnStartEnabledSwitch", switch.Switch, cg.Component)
+NukiLockAutoLockEnabledSwitch = nuki_lock_ns.class_("NukiLockAutoLockEnabledSwitch", switch.Switch, cg.Component)
+NukiLockAutoUnlockDisabledSwitch = nuki_lock_ns.class_("NukiLockAutoUnlockDisabledSwitch", switch.Switch, cg.Component)
+NukiLockImmediateAutoLockEnabledSwitch = nuki_lock_ns.class_("NukiLockImmediateAutoLockEnabledSwitch", switch.Switch, cg.Component)
+NukiLockAutoUpdateEnabledSwitch = nuki_lock_ns.class_("NukiLockAutoUpdateEnabledSwitch", switch.Switch, cg.Component)
 NukiLockLedBrightnessNumber = nuki_lock_ns.class_("NukiLockLedBrightnessNumber", number.Number, cg.Component)
+NukiLockSingleButtonPressActionSelect = nuki_lock_ns.class_("NukiLockSingleButtonPressActionSelect", select.Select, cg.Component)
+NukiLockDoubleButtonPressActionSelect = nuki_lock_ns.class_("NukiLockDoubleButtonPressActionSelect", select.Select, cg.Component)
 
 NukiLockUnpairAction = nuki_lock_ns.class_(
     "NukiLockUnpairAction", automation.Action
@@ -112,8 +141,56 @@ CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend({
         device_class=DEVICE_CLASS_SWITCH,
         entity_category=ENTITY_CATEGORY_CONFIG,
     ),
+    cv.Optional(CONF_NIGHT_MODE_ENABLED_SWITCH): switch.switch_schema(
+        NukiLockNightModeEnabledSwitch,
+        device_class=DEVICE_CLASS_SWITCH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+    ),
+    cv.Optional(CONF_NIGHT_MODE_AUTO_LOCK_ENABLED_SWITCH): switch.switch_schema(
+        NukiLockNightModeAutoLockEnabledSwitch,
+        device_class=DEVICE_CLASS_SWITCH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+    ),
+    cv.Optional(CONF_NIGHT_MODE_AUTO_UNLOCK_DISABLED_SWITCH): switch.switch_schema(
+        NukiLockNightModeAutoUnlockDisabledSwitch,
+        device_class=DEVICE_CLASS_SWITCH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+    ),
+    cv.Optional(CONF_NIGHT_MODE_IMMEDIATE_LOCK_ON_START_ENABLED_SWITCH): switch.switch_schema(
+        NukiLockNightModeImmediateLockOnStartEnabledSwitch,
+        device_class=DEVICE_CLASS_SWITCH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+    ),
+    cv.Optional(CONF_AUTO_LOCK_ENABLED_SWITCH): switch.switch_schema(
+        NukiLockAutoLockEnabledSwitch,
+        device_class=DEVICE_CLASS_SWITCH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+    ),
+    cv.Optional(CONF_AUTO_UNLOCK_DISABLED_SWITCH): switch.switch_schema(
+        NukiLockAutoUnlockDisabledSwitch,
+        device_class=DEVICE_CLASS_SWITCH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+    ),
+    cv.Optional(CONF_IMMEDIATE_AUTO_LOCK_ENABLED_SWITCH): switch.switch_schema(
+        NukiLockImmediateAutoLockEnabledSwitch,
+        device_class=DEVICE_CLASS_SWITCH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+    ),
+    cv.Optional(CONF_AUTO_UPDATE_ENABLED_SWITCH): switch.switch_schema(
+        NukiLockAutoUpdateEnabledSwitch,
+        device_class=DEVICE_CLASS_SWITCH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+    ),
     cv.Optional(CONF_LED_BRIGHTNESS_NUMBER): number.number_schema(
         NukiLockLedBrightnessNumber,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+    ),
+    cv.Optional(CONF_SINGLE_BUTTON_PRESS_ACTION_SELECT): select.select_schema(
+        NukiLockSingleButtonPressActionSelect,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+    ),
+    cv.Optional(CONF_DOUBLE_BUTTON_PRESS_ACTION_SELECT): select.select_schema(
+        NukiLockDoubleButtonPressActionSelect,
         entity_category=ENTITY_CATEGORY_CONFIG,
     ),
     cv.Optional(CONF_PAIRING_MODE_TIMEOUT, default="300s"): cv.positive_time_period_seconds,
@@ -208,6 +285,64 @@ async def to_code(config):
         s = await switch.new_switch(led_enabled)
         await cg.register_parented(s, config[CONF_ID])
         cg.add(var.set_led_enabled_switch(s))
+
+    if nightmode_enabled := config.get(CONF_NIGHT_MODE_ENABLED_SWITCH):
+        s = await switch.new_switch(nightmode_enabled)
+        await cg.register_parented(s, config[CONF_ID])
+        cg.add(var.set_nightmode_enabled_switch(s))
+
+    if night_mode_auto_lock_enabled := config.get(CONF_NIGHT_MODE_AUTO_LOCK_ENABLED_SWITCH):
+        s = await switch.new_switch(night_mode_auto_lock_enabled)
+        await cg.register_parented(s, config[CONF_ID])
+        cg.add(var.set_night_mode_auto_lock_enabled_switch(s))
+
+    if night_mode_auto_unlock_disabled := config.get(CONF_NIGHT_MODE_AUTO_UNLOCK_DISABLED_SWITCH):
+        s = await switch.new_switch(night_mode_auto_unlock_disabled)
+        await cg.register_parented(s, config[CONF_ID])
+        cg.add(var.set_night_mode_auto_unlock_disabled_switch(s))
+
+    if night_mode_immediate_lock_on_start := config.get(CONF_NIGHT_MODE_IMMEDIATE_LOCK_ON_START_ENABLED_SWITCH):
+        s = await switch.new_switch(night_mode_immediate_lock_on_start)
+        await cg.register_parented(s, config[CONF_ID])
+        cg.add(var.set_night_mode_immediate_lock_on_start_switch(s))
+
+    if auto_lock_enabled := config.get(CONF_AUTO_LOCK_ENABLED_SWITCH):
+        s = await switch.new_switch(auto_lock_enabled)
+        await cg.register_parented(s, config[CONF_ID])
+        cg.add(var.set_auto_lock_enabled_switch(s))
+
+    if auto_unlock_disabled := config.get(CONF_AUTO_UNLOCK_DISABLED_SWITCH):
+        s = await switch.new_switch(auto_unlock_disabled)
+        await cg.register_parented(s, config[CONF_ID])
+        cg.add(var.set_auto_unlock_disabled_switch(s))
+
+    if immediate_auto_lock_enabled := config.get(CONF_IMMEDIATE_AUTO_LOCK_ENABLED_SWITCH):
+        s = await switch.new_switch(immediate_auto_lock_enabled)
+        await cg.register_parented(s, config[CONF_ID])
+        cg.add(var.set_immediate_auto_lock_enabled_switch(s))
+
+    if auto_update_enabled := config.get(CONF_AUTO_UPDATE_ENABLED_SWITCH):
+        s = await switch.new_switch(auto_update_enabled)
+        await cg.register_parented(s, config[CONF_ID])
+        cg.add(var.set_auto_update_enabled_switch(s))
+
+    # Select
+    if single_button_press_action := config.get(CONF_SINGLE_BUTTON_PRESS_ACTION_SELECT):
+        sel = await select.new_select(
+            single_button_press_action,
+            options=[CONF_BUTTON_PRESS_ACTION_SELECT_OPTIONS],
+        )
+        await cg.register_parented(sel, config[CONF_ID])
+        cg.add(var.set_single_button_press_action_select(sel))
+
+    if double_button_press_action := config.get(CONF_DOUBLE_BUTTON_PRESS_ACTION_SELECT):
+        sel = await select.new_select(
+            double_button_press_action,
+            options=[CONF_BUTTON_PRESS_ACTION_SELECT_OPTIONS],
+        )
+        await cg.register_parented(sel, config[CONF_ID])
+        cg.add(var.set_double_button_press_action_select(sel))
+
 
     # Callback
     for conf in config.get(CONF_ON_PAIRING_MODE_ON, []):

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -29,7 +29,7 @@ CONF_DOOR_SENSOR_STATE = "door_sensor_state"
 CONF_UNPAIR_BUTTON = "unpair"
 
 CONF_PAIRING_MODE_SWITCH = "pairing_mode"
-CONF_AUTO_UNLATCH_ENABLED_SWITCH = "auto_unlatch_enabled"
+CONF_AUTO_UNLATCH_SWITCH = "auto_unlatch"
 CONF_BUTTON_ENABLED_SWITCH = "button_enabled"
 CONF_LED_ENABLED_SWITCH = "led_enabled"
 
@@ -102,7 +102,7 @@ CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend({
         device_class=DEVICE_CLASS_SWITCH,
         entity_category=ENTITY_CATEGORY_CONFIG,
     ),
-    cv.Optional(CONF_AUTO_UNLATCH_ENABLED_SWITCH): switch.switch_schema(
+    cv.Optional(CONF_AUTO_UNLATCH_SWITCH): switch.switch_schema(
         NukiLockAutoUnlatchEnabledSwitch,
         device_class=DEVICE_CLASS_SWITCH,
         entity_category=ENTITY_CATEGORY_CONFIG,
@@ -150,29 +150,29 @@ async def to_code(config):
     # Binary Sensor
     if is_connected := config.get(CONF_IS_CONNECTED):
         sens = await binary_sensor.new_binary_sensor(is_connected)
-        cg.add(var.set_is_connected(sens))
+        cg.add(var.set_is_connected_binary_sensor(sens))
 
     if is_paired := config.get(CONF_IS_PAIRED):
         sens = await binary_sensor.new_binary_sensor(is_paired)
-        cg.add(var.set_is_paired(sens))
+        cg.add(var.set_is_paired_binary_sensor(sens))
 
     if battery_critical := config.get(CONF_BATTERY_CRITICAL):
         sens = await binary_sensor.new_binary_sensor(battery_critical)
-        cg.add(var.set_battery_critical(sens))
+        cg.add(var.set_battery_critical_binary_sensor(sens))
 
     if door_sensor := config.get(CONF_DOOR_SENSOR):
         sens = await binary_sensor.new_binary_sensor(door_sensor)
-        cg.add(var.set_door_sensor(sens))
+        cg.add(var.set_door_sensor_binary_sensor(sens))
 
     # Sensor
     if battery_level := config.get(CONF_BATTERY_LEVEL):
         sens = await sensor.new_sensor(battery_level)
-        cg.add(var.set_battery_level(sens))
+        cg.add(var.set_battery_level_sensor(sens))
 
     # Text Sensor
     if door_sensor_state := config.get(CONF_DOOR_SENSOR_STATE):
         sens = await text_sensor.new_text_sensor(door_sensor_state)
-        cg.add(var.set_door_sensor_state(sens))
+        cg.add(var.set_door_sensor_state_text_sensor(sens))
 
     # Button
     if unpair := config.get(CONF_UNPAIR_BUTTON):
@@ -199,7 +199,7 @@ async def to_code(config):
         await cg.register_parented(s, config[CONF_ID])
         cg.add(var.set_button_enabled_switch(s))
 
-    if auto_unlatch := config.get(CONF_AUTO_UNLATCH_ENABLED_SWITCH):
+    if auto_unlatch := config.get(CONF_AUTO_UNLATCH_SWITCH):
         s = await switch.new_switch(auto_unlatch)
         await cg.register_parented(s, config[CONF_ID])
         cg.add(var.set_auto_unlatch_enabled_switch(s))
@@ -252,7 +252,7 @@ NUKI_LOCK_SET_PAIRING_MODE_SCHEMA = automation.maybe_simple_id(
 )
 
 @automation.register_action(
-    "nuki_hub.set_pairing_mode", NukiLockPairingModeAction, NUKI_LOCK_SET_PAIRING_MODE_SCHEMA
+    "nuki_lock.set_pairing_mode", NukiLockPairingModeAction, NUKI_LOCK_SET_PAIRING_MODE_SCHEMA
 )
 
 async def nuki_lock_set_pairing_mode_to_code(config, action_id, template_arg, args):

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -111,10 +111,12 @@ CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend({
     cv.Optional(CONF_SECURITY_PIN, default=0): cv.uint16_t,
     cv.Optional(CONF_BATTERY_CRITICAL): binary_sensor.binary_sensor_schema(
         device_class=DEVICE_CLASS_BATTERY,
+        icon="mdi:battery-alert-variant-outline",
     ),
     cv.Optional(CONF_BATTERY_LEVEL): sensor.sensor_schema(
         device_class=DEVICE_CLASS_BATTERY,
         unit_of_measurement=UNIT_PERCENT,
+        icon="mdi:battery-50",
     ),
     cv.Optional(CONF_DOOR_SENSOR): binary_sensor.binary_sensor_schema(
         device_class=DEVICE_CLASS_DOOR,

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -127,24 +127,32 @@ CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend({
         device_class=DEVICE_CLASS_BATTERY,
         icon="mdi:battery-alert-variant-outline",
     ),
+    cv.Optional(CONF_DOOR_SENSOR): binary_sensor.binary_sensor_schema(
+        device_class=DEVICE_CLASS_DOOR,
+        icon="mdi:door-open",
+    ),
+
+    cv.Optional(CONF_DOOR_SENSOR_STATE): text_sensor.text_sensor_schema(
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        icon="mdi:door-open",
+    ),
+    cv.Optional(CONF_LAST_UNLOCK_USER_TEXT_SENSOR):  text_sensor.text_sensor_schema(
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        icon="mdi:account-clock"
+    ),
+
     cv.Optional(CONF_BATTERY_LEVEL): sensor.sensor_schema(
         device_class=DEVICE_CLASS_BATTERY,
         unit_of_measurement=UNIT_PERCENT,
         icon="mdi:battery-50",
     ),
-    cv.Optional(CONF_DOOR_SENSOR): binary_sensor.binary_sensor_schema(
-        device_class=DEVICE_CLASS_DOOR,
-        icon="mdi:door-open",
-    ),
-    cv.Optional(CONF_DOOR_SENSOR_STATE): text_sensor.text_sensor_schema(
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        icon="mdi:door-open",
-    ),
+
     cv.Optional(CONF_UNPAIR_BUTTON): button.button_schema(
         NukiLockUnpairButton,
         entity_category=ENTITY_CATEGORY_CONFIG,
         icon="mdi:link-off",
     ),
+
     cv.Optional(CONF_PAIRING_MODE_SWITCH): switch.switch_schema(
         NukiLockPairingModeSwitch,
         entity_category=ENTITY_CATEGORY_CONFIG,
@@ -217,11 +225,13 @@ CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend({
         entity_category=ENTITY_CATEGORY_CONFIG,
         icon="mdi:auto-download",
     ),
+
     cv.Optional(CONF_LED_BRIGHTNESS_NUMBER): number.number_schema(
         NukiLockLedBrightnessNumber,
         entity_category=ENTITY_CATEGORY_CONFIG,
         icon="mdi:brightness-6",
     ),
+
     cv.Optional(CONF_SINGLE_BUTTON_PRESS_ACTION_SELECT): select.select_schema(
         NukiLockSingleButtonPressActionSelect,
         entity_category=ENTITY_CATEGORY_CONFIG,
@@ -247,12 +257,11 @@ CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend({
         entity_category=ENTITY_CATEGORY_CONFIG,
         icon="mdi:gesture-tap",
     ),
-    cv.Optional(CONF_LAST_UNLOCK_USER_TEXT_SENSOR):  text_sensor.text_sensor_schema(
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
+
     cv.Optional(CONF_SECURITY_PIN, default=0): cv.uint16_t,
     cv.Optional(CONF_PAIRING_MODE_TIMEOUT, default="300s"): cv.positive_time_period_seconds,
     cv.Optional(CONF_EVENT, default="nuki"): cv.string,
+
     cv.Optional(CONF_ON_PAIRING_MODE_ON): automation.validate_automation(
         {
             cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PairingModeOnTrigger),

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -25,6 +25,7 @@ CONF_DOOR_SENSOR = "door_sensor"
 CONF_BATTERY_LEVEL = "battery_level"
 
 CONF_DOOR_SENSOR_STATE = "door_sensor_state"
+CONF_LAST_UNLOCK_USER_TEXT_SENSOR = "last_unlock_user"
 
 CONF_UNPAIR_BUTTON = "unpair"
 
@@ -215,6 +216,9 @@ CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend({
         entity_category=ENTITY_CATEGORY_CONFIG,
         icon="mdi:gesture-tap",
     ),
+    cv.Optional(CONF_LAST_UNLOCK_USER_TEXT_SENSOR):  text_sensor.text_sensor_schema(
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
     cv.Optional(CONF_PAIRING_MODE_TIMEOUT, default="300s"): cv.positive_time_period_seconds,
     cv.Optional(CONF_ON_PAIRING_MODE_ON): automation.validate_automation(
         {
@@ -272,6 +276,10 @@ async def to_code(config):
     if door_sensor_state := config.get(CONF_DOOR_SENSOR_STATE):
         sens = await text_sensor.new_text_sensor(door_sensor_state)
         cg.add(var.set_door_sensor_state_text_sensor(sens))
+
+    if last_unlock_user := config.get(CONF_LAST_UNLOCK_USER_TEXT_SENSOR):
+        sens = await text_sensor.new_text_sensor(last_unlock_user)
+        cg.add(var.set_last_unlock_user_text_sensor(sens))
 
     # Button
     if unpair := config.get(CONF_UNPAIR_BUTTON):

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -1,33 +1,43 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import lock, binary_sensor, text_sensor, sensor, switch, button
+from esphome.components import lock, binary_sensor, text_sensor, sensor, switch, button, number, select
 from esphome.const import (
     CONF_ID, 
     CONF_BATTERY_LEVEL, 
     DEVICE_CLASS_CONNECTIVITY, 
     DEVICE_CLASS_BATTERY, 
     DEVICE_CLASS_DOOR, 
+    DEVICE_CLASS_SWITCH,
     UNIT_PERCENT,
     ENTITY_CATEGORY_CONFIG, 
     ENTITY_CATEGORY_DIAGNOSTIC,
     CONF_TRIGGER_ID
 )
 
-AUTO_LOAD = ["binary_sensor", "text_sensor", "sensor", "switch", "button"]
+AUTO_LOAD = ["binary_sensor", "text_sensor", "sensor", "switch", "button", "number", "select"]
 
 CONF_IS_CONNECTED = "is_connected"
 CONF_IS_PAIRED = "is_paired"
-CONF_SECURITY_PIN = "security_pin"
-CONF_UNPAIR_BUTTON = "unpair"
-CONF_PAIRING_MODE_SWITCH = "pairing_mode"
 CONF_BATTERY_CRITICAL = "battery_critical"
-CONF_BATTERY_LEVEL = "battery_level"
 CONF_DOOR_SENSOR = "door_sensor"
+
+CONF_BATTERY_LEVEL = "battery_level"
+
 CONF_DOOR_SENSOR_STATE = "door_sensor_state"
 
-CONF_SET_PAIRING_MODE = "pairing_mode"
+CONF_UNPAIR_BUTTON = "unpair"
+
+CONF_PAIRING_MODE_SWITCH = "pairing_mode"
+CONF_BUTTON_ENABLED_SWITCH = "button_enabled"
+CONF_LED_ENABLED_SWITCH = "led_enabled"
+
+CONF_LED_BRIGHTNESS_NUMBER = "led_brightness"
+
 CONF_PAIRING_MODE_TIMEOUT = "pairing_mode_timeout"
+CONF_SECURITY_PIN = "security_pin"
+
+CONF_SET_PAIRING_MODE = "pairing_mode"
 
 CONF_ON_PAIRING_MODE_ON = "on_pairing_mode_on_action"
 CONF_ON_PAIRING_MODE_OFF = "on_pairing_mode_off_action"
@@ -38,6 +48,9 @@ NukiLock = nuki_lock_ns.class_('NukiLockComponent', lock.Lock, switch.Switch, cg
 
 NukiLockUnpairButton = nuki_lock_ns.class_("NukiLockUnpairButton", button.Button, cg.Component)
 NukiLockPairingModeSwitch = nuki_lock_ns.class_("NukiLockPairingModeSwitch", switch.Switch, cg.Component)
+NukiLockButtonEnabledSwitch = nuki_lock_ns.class_("NukiLockButtonEnabledSwitch", switch.Switch, cg.Component)
+NukiLockLedEnabledSwitch = nuki_lock_ns.class_("NukiLockLedEnabledSwitch", switch.Switch, cg.Component)
+NukiLockLedBrightnessNumber = nuki_lock_ns.class_("NukiLockLedBrightnessNumber", number.Number, cg.Component)
 
 NukiLockUnpairAction = nuki_lock_ns.class_(
     "NukiLockUnpairAction", automation.Action
@@ -81,7 +94,20 @@ CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend({
     cv.Optional(CONF_PAIRING_MODE_SWITCH): switch.switch_schema(
         NukiLockPairingModeSwitch,
         entity_category=ENTITY_CATEGORY_CONFIG,
-        icon="mdi:bluetooth-connect",
+    ),
+    cv.Optional(CONF_BUTTON_ENABLED_SWITCH): switch.switch_schema(
+        NukiLockButtonEnabledSwitch,
+        device_class=DEVICE_CLASS_SWITCH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+    ),
+    cv.Optional(CONF_LED_ENABLED_SWITCH): switch.switch_schema(
+        NukiLockLedEnabledSwitch,
+        device_class=DEVICE_CLASS_SWITCH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+    ),
+    cv.Optional(CONF_LED_BRIGHTNESS_NUMBER): number.number_schema(
+        NukiLockLedBrightnessNumber,
+        entity_category=ENTITY_CATEGORY_CONFIG,
     ),
     cv.Optional(CONF_PAIRING_MODE_TIMEOUT, default="300s"): cv.positive_time_period_seconds,
     cv.Optional(CONF_ON_PAIRING_MODE_ON): automation.validate_automation(
@@ -106,41 +132,72 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await lock.register_lock(var, config)
-    if CONF_IS_CONNECTED in config:
-        sens = await binary_sensor.new_binary_sensor(config[CONF_IS_CONNECTED])
-        cg.add(var.set_is_connected(sens))
-    if CONF_IS_PAIRED in config:
-        sens = await binary_sensor.new_binary_sensor(config[CONF_IS_PAIRED])
-        cg.add(var.set_is_paired(sens))
 
+    # Component Settings
     if CONF_SECURITY_PIN in config:
         cg.add(var.set_security_pin(config[CONF_SECURITY_PIN]))
 
-    if CONF_BATTERY_CRITICAL in config:
-        sens = await binary_sensor.new_binary_sensor(config[CONF_BATTERY_CRITICAL])
+    if CONF_PAIRING_MODE_TIMEOUT in config:
+        cg.add(var.set_pairing_mode_timeout(config[CONF_PAIRING_MODE_TIMEOUT]))
+
+    # Binary Sensor
+    if is_connected := config.get(CONF_IS_CONNECTED):
+        sens = await binary_sensor.new_binary_sensor(is_connected)
+        cg.add(var.set_is_connected(sens))
+
+    if is_paired := config.get(CONF_IS_PAIRED):
+        sens = await binary_sensor.new_binary_sensor(is_paired)
+        cg.add(var.set_is_paired(sens))
+
+    if battery_critical := config.get(CONF_BATTERY_CRITICAL):
+        sens = await binary_sensor.new_binary_sensor(battery_critical)
         cg.add(var.set_battery_critical(sens))
-    if CONF_BATTERY_LEVEL in config:
-        sens = await sensor.new_sensor(config[CONF_BATTERY_LEVEL])
-        cg.add(var.set_battery_level(sens))
-    if CONF_DOOR_SENSOR in config:
-        sens = await binary_sensor.new_binary_sensor(config[CONF_DOOR_SENSOR])
+
+    if door_sensor := config.get(CONF_DOOR_SENSOR):
+        sens = await binary_sensor.new_binary_sensor(door_sensor)
         cg.add(var.set_door_sensor(sens))
-    if CONF_DOOR_SENSOR_STATE in config:
-        sens = await text_sensor.new_text_sensor(config[CONF_DOOR_SENSOR_STATE])
+
+    # Sensor
+    if battery_level := config.get(CONF_BATTERY_LEVEL):
+        sens = await sensor.new_sensor(battery_level)
+        cg.add(var.set_battery_level(sens))
+
+    # Text Sensor
+    if door_sensor_state := config.get(CONF_DOOR_SENSOR_STATE):
+        sens = await text_sensor.new_text_sensor(door_sensor_state)
         cg.add(var.set_door_sensor_state(sens))
 
-    if CONF_UNPAIR_BUTTON in config:
-        btn = await button.new_button(config[CONF_UNPAIR_BUTTON])
-        await cg.register_parented(btn, config[CONF_ID])
-        cg.add(var.set_unpair_button(btn))
+    # Button
+    if unpair := config.get(CONF_UNPAIR_BUTTON):
+        b = await button.new_button(unpair)
+        await cg.register_parented(b, config[CONF_ID])
+        cg.add(var.set_unpair_button(b))
 
-    if CONF_PAIRING_MODE_SWITCH in config:
-        sw = await switch.new_switch(config[CONF_PAIRING_MODE_SWITCH])
-        await cg.register_parented(sw, config[CONF_ID])
-        cg.add(var.set_pairing_mode_switch(sw))
+    # Number
+    if led_brightness := config.get(CONF_LED_BRIGHTNESS_NUMBER):
+        n = await number.new_number(
+            led_brightness, min_value=0, max_value=5, step=1
+        )
+        await cg.register_parented(n, config[CONF_ID])
+        cg.add(var.set_led_brightness_number(n))
 
-    cg.add(var.set_pairing_mode_timeout(config[CONF_PAIRING_MODE_TIMEOUT]))
+    # Switch
+    if pairing_mode := config.get(CONF_PAIRING_MODE_SWITCH):
+        s = await switch.new_switch(pairing_mode)
+        await cg.register_parented(s, config[CONF_ID])
+        cg.add(var.set_pairing_mode_switch(s))
 
+    if button_enabled := config.get(CONF_BUTTON_ENABLED_SWITCH):
+        s = await switch.new_switch(button_enabled)
+        await cg.register_parented(s, config[CONF_ID])
+        cg.add(var.set_button_enabled_switch(s))
+
+    if led_enabled := config.get(CONF_LED_ENABLED_SWITCH):
+        s = await switch.new_switch(led_enabled)
+        await cg.register_parented(s, config[CONF_ID])
+        cg.add(var.set_led_enabled_switch(s))
+
+    # Callback
     for conf in config.get(CONF_ON_PAIRING_MODE_ON, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
@@ -153,30 +210,39 @@ async def to_code(config):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
 
-@automation.register_action(
-    "nuki_lock.unpair",
-    NukiLockUnpairAction,
-    automation.maybe_simple_id(
-        {
-            cv.GenerateID(): cv.use_id(NukiLock)
-        }
-    ),
+
+# Actions
+NukiLockUnpairAction = nuki_lock_ns.class_(
+    "NukiLockUnpairAction", automation.Action
 )
+
+NUKI_LOCK_UNPAIR_SCHEMA = automation.maybe_simple_id(
+    {
+        cv.GenerateID(): cv.use_id(NukiLock)
+    }
+)
+
+@automation.register_action(
+    "nuki_lock.unpair", NukiLockUnpairAction, NUKI_LOCK_UNPAIR_SCHEMA
+)
+
 async def nuki_lock_unpair_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
 
-@automation.register_action(
-    "nuki_lock.set_pairing_mode",
-    NukiLockPairingModeAction,
-    automation.maybe_simple_id(
-        {
-            cv.GenerateID(): cv.use_id(NukiLock),
-            cv.Required(CONF_SET_PAIRING_MODE): cv.templatable(cv.boolean)
-        }
-    ),
+
+NUKI_LOCK_SET_PAIRING_MODE_SCHEMA = automation.maybe_simple_id(
+    {
+        cv.GenerateID(): cv.use_id(NukiLock),
+        cv.Required(CONF_SET_PAIRING_MODE): cv.templatable(cv.boolean)
+    }
 )
+
+@automation.register_action(
+    "nuki_hub.set_pairing_mode", NukiLockPairingModeAction, NUKI_LOCK_SET_PAIRING_MODE_SCHEMA
+)
+
 async def nuki_lock_set_pairing_mode_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -100,10 +100,12 @@ CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend({
     cv.Required(CONF_IS_CONNECTED): binary_sensor.binary_sensor_schema(
         device_class=DEVICE_CLASS_CONNECTIVITY,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        icon="mdi:link"
     ),
     cv.Required(CONF_IS_PAIRED): binary_sensor.binary_sensor_schema(
         device_class=DEVICE_CLASS_CONNECTIVITY,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        icon="mdi:link"
     ),
     cv.Optional(CONF_SECURITY_PIN, default=0): cv.uint16_t,
     cv.Optional(CONF_BATTERY_CRITICAL): binary_sensor.binary_sensor_schema(
@@ -115,8 +117,12 @@ CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend({
     ),
     cv.Optional(CONF_DOOR_SENSOR): binary_sensor.binary_sensor_schema(
         device_class=DEVICE_CLASS_DOOR,
+        icon="mdi:door-open",
     ),
-    cv.Optional(CONF_DOOR_SENSOR_STATE): text_sensor.text_sensor_schema(),
+    cv.Optional(CONF_DOOR_SENSOR_STATE): text_sensor.text_sensor_schema(
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        icon="mdi:door-open",
+    ),
     cv.Optional(CONF_UNPAIR_BUTTON): button.button_schema(
         NukiLockUnpairButton,
         entity_category=ENTITY_CATEGORY_CONFIG,
@@ -125,73 +131,89 @@ CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend({
     cv.Optional(CONF_PAIRING_MODE_SWITCH): switch.switch_schema(
         NukiLockPairingModeSwitch,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:bluetooth"
     ),
     cv.Optional(CONF_BUTTON_ENABLED_SWITCH): switch.switch_schema(
         NukiLockButtonEnabledSwitch,
         device_class=DEVICE_CLASS_SWITCH,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:radiobox-marked"
     ),
     cv.Optional(CONF_AUTO_UNLATCH_SWITCH): switch.switch_schema(
         NukiLockAutoUnlatchEnabledSwitch,
         device_class=DEVICE_CLASS_SWITCH,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:auto-upload"
     ),
     cv.Optional(CONF_LED_ENABLED_SWITCH): switch.switch_schema(
         NukiLockLedEnabledSwitch,
         device_class=DEVICE_CLASS_SWITCH,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:led-on"
     ),
     cv.Optional(CONF_NIGHT_MODE_ENABLED_SWITCH): switch.switch_schema(
         NukiLockNightModeEnabledSwitch,
         device_class=DEVICE_CLASS_SWITCH,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:shield-moon",
     ),
     cv.Optional(CONF_NIGHT_MODE_AUTO_LOCK_ENABLED_SWITCH): switch.switch_schema(
         NukiLockNightModeAutoLockEnabledSwitch,
         device_class=DEVICE_CLASS_SWITCH,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:lock-clock"
     ),
     cv.Optional(CONF_NIGHT_MODE_AUTO_UNLOCK_DISABLED_SWITCH): switch.switch_schema(
         NukiLockNightModeAutoUnlockDisabledSwitch,
         device_class=DEVICE_CLASS_SWITCH,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:lock-remove"
     ),
     cv.Optional(CONF_NIGHT_MODE_IMMEDIATE_LOCK_ON_START_ENABLED_SWITCH): switch.switch_schema(
         NukiLockNightModeImmediateLockOnStartEnabledSwitch,
         device_class=DEVICE_CLASS_SWITCH,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:lock-alert"
     ),
     cv.Optional(CONF_AUTO_LOCK_ENABLED_SWITCH): switch.switch_schema(
         NukiLockAutoLockEnabledSwitch,
         device_class=DEVICE_CLASS_SWITCH,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:lock-clock"
     ),
     cv.Optional(CONF_AUTO_UNLOCK_DISABLED_SWITCH): switch.switch_schema(
         NukiLockAutoUnlockDisabledSwitch,
         device_class=DEVICE_CLASS_SWITCH,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:lock-remove"
     ),
     cv.Optional(CONF_IMMEDIATE_AUTO_LOCK_ENABLED_SWITCH): switch.switch_schema(
         NukiLockImmediateAutoLockEnabledSwitch,
         device_class=DEVICE_CLASS_SWITCH,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:lock-alert"
+        
     ),
     cv.Optional(CONF_AUTO_UPDATE_ENABLED_SWITCH): switch.switch_schema(
         NukiLockAutoUpdateEnabledSwitch,
         device_class=DEVICE_CLASS_SWITCH,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:auto-download",
     ),
     cv.Optional(CONF_LED_BRIGHTNESS_NUMBER): number.number_schema(
         NukiLockLedBrightnessNumber,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:brightness-6",
     ),
     cv.Optional(CONF_SINGLE_BUTTON_PRESS_ACTION_SELECT): select.select_schema(
         NukiLockSingleButtonPressActionSelect,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:gesture-tap",
     ),
     cv.Optional(CONF_DOUBLE_BUTTON_PRESS_ACTION_SELECT): select.select_schema(
         NukiLockDoubleButtonPressActionSelect,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:gesture-tap",
     ),
     cv.Optional(CONF_PAIRING_MODE_TIMEOUT, default="300s"): cv.positive_time_period_seconds,
     cv.Optional(CONF_ON_PAIRING_MODE_ON): automation.validate_automation(

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -43,6 +43,9 @@ CONF_IMMEDIATE_AUTO_LOCK_ENABLED_SWITCH = "immediate_auto_lock_enabled"
 CONF_AUTO_UPDATE_ENABLED_SWITCH = "auto_update_enabled"
 CONF_SINGLE_BUTTON_PRESS_ACTION_SELECT = "single_buton_press_action"
 CONF_DOUBLE_BUTTON_PRESS_ACTION_SELECT = "double_buton_press_action"
+CONF_FOB_ACTION_1_SELECT = "fob_action_1"
+CONF_FOB_ACTION_2_SELECT = "fob_action_2"
+CONF_FOB_ACTION_3_SELECT = "fob_action_3"
 CONF_LED_BRIGHTNESS_NUMBER = "led_brightness"
 
 CONF_BUTTON_PRESS_ACTION_SELECT_OPTIONS = [
@@ -53,6 +56,14 @@ CONF_BUTTON_PRESS_ACTION_SELECT_OPTIONS = [
     "Unlatch",
     "Lock n Go",
     "Show Status",
+]
+
+CONF_FOB_ACTION_SELECT_OPTIONS = [
+    "No Action",
+    "Unlock",
+    "Lock",
+    "Lock n Go",
+    "Intelligent",
 ]
 
 CONF_PAIRING_MODE_TIMEOUT = "pairing_mode_timeout"
@@ -84,6 +95,9 @@ NukiLockAutoUpdateEnabledSwitch = nuki_lock_ns.class_("NukiLockAutoUpdateEnabled
 NukiLockLedBrightnessNumber = nuki_lock_ns.class_("NukiLockLedBrightnessNumber", number.Number, cg.Component)
 NukiLockSingleButtonPressActionSelect = nuki_lock_ns.class_("NukiLockSingleButtonPressActionSelect", select.Select, cg.Component)
 NukiLockDoubleButtonPressActionSelect = nuki_lock_ns.class_("NukiLockDoubleButtonPressActionSelect", select.Select, cg.Component)
+NukiLockFobAction1Select = nuki_lock_ns.class_("NukiLockFobAction1Select", select.Select, cg.Component)
+NukiLockFobAction2Select = nuki_lock_ns.class_("NukiLockFobAction2Select", select.Select, cg.Component)
+NukiLockFobAction3Select = nuki_lock_ns.class_("NukiLockFobAction3Select", select.Select, cg.Component)
 
 NukiLockUnpairAction = nuki_lock_ns.class_(
     "NukiLockUnpairAction", automation.Action
@@ -215,6 +229,21 @@ CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend({
     ),
     cv.Optional(CONF_DOUBLE_BUTTON_PRESS_ACTION_SELECT): select.select_schema(
         NukiLockDoubleButtonPressActionSelect,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:gesture-tap",
+    ),
+    cv.Optional(CONF_FOB_ACTION_1_SELECT): select.select_schema(
+        NukiLockFobAction1Select,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:gesture-tap",
+    ),
+    cv.Optional(CONF_FOB_ACTION_2_SELECT): select.select_schema(
+        NukiLockFobAction2Select,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:gesture-tap",
+    ),
+    cv.Optional(CONF_FOB_ACTION_3_SELECT): select.select_schema(
+        NukiLockFobAction3Select,
         entity_category=ENTITY_CATEGORY_CONFIG,
         icon="mdi:gesture-tap",
     ),
@@ -379,6 +408,30 @@ async def to_code(config):
         )
         await cg.register_parented(sel, config[CONF_ID])
         cg.add(var.set_double_button_press_action_select(sel))
+
+    if fob_action_1 := config.get(CONF_FOB_ACTION_1_SELECT):
+        sel = await select.new_select(
+            fob_action_1,
+            options=[CONF_FOB_ACTION_SELECT_OPTIONS],
+        )
+        await cg.register_parented(sel, config[CONF_ID])
+        cg.add(var.set_fob_action_1_select(sel))
+
+    if fob_action_2 := config.get(CONF_FOB_ACTION_2_SELECT):
+        sel = await select.new_select(
+            fob_action_2,
+            options=[CONF_FOB_ACTION_SELECT_OPTIONS],
+        )
+        await cg.register_parented(sel, config[CONF_ID])
+        cg.add(var.set_fob_action_2_select(sel))
+
+    if fob_action_3 := config.get(CONF_FOB_ACTION_3_SELECT):
+        sel = await select.new_select(
+            fob_action_3,
+            options=[CONF_FOB_ACTION_SELECT_OPTIONS],
+        )
+        await cg.register_parented(sel, config[CONF_ID])
+        cg.add(var.set_fob_action_3_select(sel))
 
 
     # Callback

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -57,6 +57,7 @@ CONF_BUTTON_PRESS_ACTION_SELECT_OPTIONS = [
 
 CONF_PAIRING_MODE_TIMEOUT = "pairing_mode_timeout"
 CONF_SECURITY_PIN = "security_pin"
+CONF_EVENT = "event"
 
 CONF_SET_PAIRING_MODE = "pairing_mode"
 
@@ -108,7 +109,6 @@ CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend({
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         icon="mdi:link"
     ),
-    cv.Optional(CONF_SECURITY_PIN, default=0): cv.uint16_t,
     cv.Optional(CONF_BATTERY_CRITICAL): binary_sensor.binary_sensor_schema(
         device_class=DEVICE_CLASS_BATTERY,
         icon="mdi:battery-alert-variant-outline",
@@ -221,7 +221,9 @@ CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend({
     cv.Optional(CONF_LAST_UNLOCK_USER_TEXT_SENSOR):  text_sensor.text_sensor_schema(
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
+    cv.Optional(CONF_SECURITY_PIN, default=0): cv.uint16_t,
     cv.Optional(CONF_PAIRING_MODE_TIMEOUT, default="300s"): cv.positive_time_period_seconds,
+    cv.Optional(CONF_EVENT, default="nuki"): cv.string,
     cv.Optional(CONF_ON_PAIRING_MODE_ON): automation.validate_automation(
         {
             cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PairingModeOnTrigger),
@@ -251,6 +253,9 @@ async def to_code(config):
 
     if CONF_PAIRING_MODE_TIMEOUT in config:
         cg.add(var.set_pairing_mode_timeout(config[CONF_PAIRING_MODE_TIMEOUT]))
+
+    if CONF_EVENT in config:
+        cg.add(var.set_event("esphome." + config[CONF_EVENT]))
 
     # Binary Sensor
     if is_connected := config.get(CONF_IS_CONNECTED):

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -97,17 +97,17 @@ std::string NukiLockComponent::fob_action_to_string(uint8_t action)
     if(action == 2) return "Lock";
     if(action == 3) return "Lock n Go";
     if(action == 4) return "Intelligent";
-    return 99;
+    return "No Action";
 }
 
 void NukiLockComponent::update_status()
 {
     this->status_update_ = false;
-    Nuki::CmdResult cmdResult = this->nuki_lock_.requestKeyTurnerState(&(this->retrieved_key_turner_state_));
-    char cmdResultAsString[30];
-    NukiLock::cmdResultToString(cmdResult, cmdResultAsString);
+    Nuki::CmdResult cmd_result = this->nuki_lock_.requestKeyTurnerState(&(this->retrieved_key_turner_state_));
+    char cmd_result_as_string[30];
+    NukiLock::cmdResultToString(cmd_result, cmd_result_as_string);
 
-    if (cmdResult == Nuki::CmdResult::Success) {
+    if (cmd_result == Nuki::CmdResult::Success) {
         this->status_update_consecutive_errors_ = 0;
         NukiLock::LockState currentLockState = this->retrieved_key_turner_state_.lockState;
         char currentLockStateAsString[30];
@@ -154,7 +154,7 @@ void NukiLockComponent::update_status()
             this->status_update_ = true;
         }
     } else {
-        ESP_LOGE(TAG, "requestKeyTurnerState failed with error %s (%d)", cmdResultAsString, cmdResult);
+        ESP_LOGE(TAG, "requestKeyTurnerState failed with error %s (%d)", cmd_result_as_string, cmd_result);
         this->status_update_ = true;
 
         this->status_update_consecutive_errors_++;
@@ -172,12 +172,12 @@ void NukiLockComponent::update_config() {
     this->config_update_ = false;
 
     NukiLock::Config config;
-    Nuki::CmdResult confReqResult = this->nuki_lock_.requestConfig(&config);
-    char confReqResultAsString[30];
-    NukiLock::cmdResultToString(confReqResult, confReqResultAsString);
+    Nuki::CmdResult conf_req_result = this->nuki_lock_.requestConfig(&config);
+    char conf_req_result_as_string[30];
+    NukiLock::cmdResultToString(conf_req_result, conf_req_result_as_string);
 
-    if (confReqResult == Nuki::CmdResult::Success) {
-        ESP_LOGD(TAG, "requestConfig has resulted in %s (%d)", confReqResultAsString, confReqResult);
+    if (conf_req_result == Nuki::CmdResult::Success) {
+        ESP_LOGD(TAG, "requestConfig has resulted in %s (%d)", conf_req_result_as_string, conf_req_result);
         keypad_paired_ = config.hasKeypad;
 
         #ifdef USE_SWITCH
@@ -202,7 +202,7 @@ void NukiLockComponent::update_config() {
         #endif
 
     } else {
-        ESP_LOGE(TAG, "requestConfig has resulted in %s (%d)", confReqResultAsString, confReqResult);
+        ESP_LOGE(TAG, "requestConfig has resulted in %s (%d)", conf_req_result_as_string, conf_req_result);
         this->config_update_ = true;
     }
 }
@@ -211,12 +211,12 @@ void NukiLockComponent::update_advanced_config() {
     this->advanced_config_update_ = false;
 
     NukiLock::AdvancedConfig advanced_config;
-    Nuki::CmdResult confReqResult = this->nuki_lock_.requestAdvancedConfig(&advanced_config);
-    char confReqResultAsString[30];
-    NukiLock::cmdResultToString(confReqResult, confReqResultAsString);
+    Nuki::CmdResult conf_req_result = this->nuki_lock_.requestAdvancedConfig(&advanced_config);
+    char conf_req_result_as_string[30];
+    NukiLock::cmdResultToString(conf_req_result, conf_req_result_as_string);
 
-    if (confReqResult == Nuki::CmdResult::Success) {
-        ESP_LOGD(TAG, "requestAdvancedConfig has resulted in %s (%d)", confReqResultAsString, confReqResult);
+    if (conf_req_result == Nuki::CmdResult::Success) {
+        ESP_LOGD(TAG, "requestAdvancedConfig has resulted in %s (%d)", conf_req_result_as_string, conf_req_result);
 
         #ifdef USE_SWITCH
         if (this->nightmode_enabled_switch_ != nullptr)
@@ -252,7 +252,7 @@ void NukiLockComponent::update_advanced_config() {
         #endif
 
     } else {
-        ESP_LOGE(TAG, "requestAdvancedConfig has resulted in %s (%d)", confReqResultAsString, confReqResult);
+        ESP_LOGE(TAG, "requestAdvancedConfig has resulted in %s (%d)", conf_req_result_as_string, conf_req_result);
         this->advanced_config_update_ = true;
     }
 }
@@ -261,14 +261,14 @@ void NukiLockComponent::update_auth_data()
 {
     this->auth_data_update_ = false;
 
-    Nuki::CmdResult confReqResult = (Nuki::CmdResult)-1;
+    Nuki::CmdResult conf_req_result = (Nuki::CmdResult)-1;
     int retryCount = 0;
     while(retryCount < 3)
     {
         ESP_LOGD(TAG, "Retrieve Auth Data");
-        confReqResult = this->nuki_lock_.retrieveAuthorizationEntries(0, MAX_AUTH_DATA_ENTRIES);
+        conf_req_result = this->nuki_lock_.retrieveAuthorizationEntries(0, MAX_AUTH_DATA_ENTRIES);
 
-        if(confReqResult != Nuki::CmdResult::Success)
+        if(conf_req_result != Nuki::CmdResult::Success)
         {
             ++retryCount;
             App.feed_wdt();
@@ -306,14 +306,14 @@ void NukiLockComponent::update_event_logs()
 {
     this->event_log_update_ = false;
 
-    Nuki::CmdResult confReqResult = (Nuki::CmdResult)-1;
+    Nuki::CmdResult conf_req_result = (Nuki::CmdResult)-1;
     int retryCount = 0;
     while(retryCount < 3)
     {
         ESP_LOGD(TAG, "Retrieve Event Logs");
-        confReqResult = this->nuki_lock_.retrieveLogEntries(0, MAX_EVENT_LOG_ENTRIES, 1, false);
+        conf_req_result = this->nuki_lock_.retrieveLogEntries(0, MAX_EVENT_LOG_ENTRIES, 1, false);
 
-        if(confReqResult != Nuki::CmdResult::Success)
+        if(conf_req_result != Nuki::CmdResult::Success)
         {
             ++retryCount;
             App.feed_wdt();
@@ -930,83 +930,6 @@ void NukiLockComponent::unpair() {
     }
 }
 
-void NukiLockComponent::set_single_button_press_action(const std::string &action) {
-
-    NukiLock::ButtonPressAction press_action = this->nuki_button_press_action_to_enum(action);
-    Nuki::CmdResult cmdResult = this->nuki_lock_.setSingleButtonPressAction(press_action);
-
-    #ifdef USE_SELECT
-    if (cmdResult == Nuki::CmdResult::Success && this->single_button_press_action_select_ != nullptr) {
-        this->single_button_press_action_select_->publish_state(action);
-        this->advanced_config_update_ = true;
-    }
-    #endif
-}
-
-void NukiLockComponent::set_double_button_press_action(const std::string &action) {
-
-    NukiLock::ButtonPressAction press_action = this->nuki_button_press_action_to_enum(action);
-    Nuki::CmdResult cmdResult = this->nuki_lock_.setDoubleButtonPressAction(press_action);
-
-    #ifdef USE_SELECT
-    if (cmdResult == Nuki::CmdResult::Success && this->double_button_press_action_select_ != nullptr) {
-        this->double_button_press_action_select_->publish_state(action);
-        this->advanced_config_update_ = true;
-    }
-    #endif
-}
-
-void NukiLockComponent::set_fob_action_1(const std::string &action) {
-
-    const uint8_t fob_action = this->fob_action_to_int(jsonchar);
-
-    if(fob_action != 99)
-    {
-        Nuki::CmdResult cmdResult = this->nuki_lock_.setFobAction(3, fob_action);
-
-        #ifdef USE_SELECT
-        if (cmdResult == Nuki::CmdResult::Success && this->fob_action_1_select_ != nullptr) {
-            this->fob_action_1_select_->publish_state(action);
-            this->config_update_ = true;
-        }
-        #endif
-    }
-}
-
-void NukiLockComponent::set_fob_action_2(const std::string &action) {
-
-    const uint8_t fob_action = this->fob_action_to_int(jsonchar);
-
-    if(fob_action != 99)
-    {
-        Nuki::CmdResult cmdResult = this->nuki_lock_.setFobAction(3, fob_action);
-
-        #ifdef USE_SELECT
-        if (cmdResult == Nuki::CmdResult::Success && this->fob_action_2_select_ != nullptr) {
-            this->fob_action_2_select_->publish_state(action);
-            this->config_update_ = true;
-        }
-        #endif
-    }
-}
-
-void NukiLockComponent::set_fob_action_3(const std::string &action) {
-
-    const uint8_t fob_action = this->fob_action_to_int(jsonchar);
-
-    if(fob_action != 99)
-    {
-        Nuki::CmdResult cmdResult = this->nuki_lock_.setFobAction(3, fob_action);
-
-        #ifdef USE_SELECT
-        if (cmdResult == Nuki::CmdResult::Success && this->fob_action_3_select_ != nullptr) {
-            this->fob_action_3_select_->publish_state(action);
-            this->config_update_ = true;
-        }
-        #endif
-    }
-}
-
 void NukiLockComponent::set_pairing_mode(bool enabled) {
     this->pairing_mode_ = enabled;
 
@@ -1032,149 +955,215 @@ void NukiLockComponent::set_pairing_mode(bool enabled) {
     }
 }
 
-void NukiLockComponent::set_auto_unlatch_enabled(bool enabled) {
+#ifdef USE_SELECT
+void NukiLockComponent::set_config_select(std::string config, const std::string &value) {
 
-    Nuki::CmdResult cmdResult = this->nuki_lock_.enableAutoUnlatch(enabled);
+    Nuki::CmdResult cmd_result = (Nuki::CmdResult)-1;
+    bool is_advanced = false;
 
-    #ifdef USE_SWITCH
-    if (cmdResult == Nuki::CmdResult::Success && this->auto_unlatch_enabled_switch_ != nullptr) {
-        this->auto_unlatch_enabled_switch_->publish_state(enabled);
-        this->config_update_ = true;
+    // Update Config
+    if(config == "single_button_press_action")
+    {
+        NukiLock::ButtonPressAction action = this->nuki_button_press_action_to_enum(value);
+        cmd_result = this->nuki_lock_.setSingleButtonPressAction(action);
+        is_advanced = true;
     }
-    #endif
-}
-
-void NukiLockComponent::set_button_enabled(bool enabled) {
-
-    Nuki::CmdResult cmdResult = this->nuki_lock_.enableButton(enabled);
-
-    #ifdef USE_SWITCH
-    if (cmdResult == Nuki::CmdResult::Success && this->button_enabled_switch_ != nullptr) {
-        this->button_enabled_switch_->publish_state(enabled);
-        this->config_update_ = true;
+    else if(config == "double_button_press_action")
+    {
+        NukiLock::ButtonPressAction action = this->nuki_button_press_action_to_enum(value);
+        cmd_result = this->nuki_lock_.setDoubleButtonPressAction(action);
+        is_advanced = true;
     }
-    #endif
-}
-
-void NukiLockComponent::set_led_enabled(bool enabled) {
-    
-    Nuki::CmdResult cmdResult = this->nuki_lock_.enableLedFlash(enabled);
-
-    #ifdef USE_SWITCH
-    if (cmdResult == Nuki::CmdResult::Success && this->led_enabled_switch_ != nullptr) {
-        this->led_enabled_switch_->publish_state(enabled);
-        this->config_update_ = true;
+    else if(config == "fob_action_1")
+    {
+        const uint8_t action = this->fob_action_to_int(value);
+        if(action != 99)
+        {
+            cmd_result = this->nuki_lock_.setFobAction(1, action);
+        }
     }
-    #endif
-}
-
-void NukiLockComponent::set_nightmode_enabled(bool enabled) {
-    
-    Nuki::CmdResult cmdResult = this->nuki_lock_.enableNightMode(enabled);
-
-    #ifdef USE_SWITCH
-    if (cmdResult == Nuki::CmdResult::Success && this->nightmode_enabled_switch_ != nullptr) {
-        this->nightmode_enabled_switch_->publish_state(enabled);
-        this->advanced_config_update_ = true;
+    else if(config == "fob_action_2")
+    {
+        const uint8_t action = this->fob_action_to_int(value);
+        if(action != 99)
+        {
+            cmd_result = this->nuki_lock_.setFobAction(2, action);
+        }
     }
-    #endif
-}
-
-void NukiLockComponent::set_night_mode_auto_lock_enabled(bool enabled) {
-    
-    Nuki::CmdResult cmdResult = this->nuki_lock_.enableNightModeAutoLock(enabled);
-
-    #ifdef USE_SWITCH
-    if (cmdResult == Nuki::CmdResult::Success && this->night_mode_auto_lock_enabled_switch_ != nullptr) {
-        this->night_mode_auto_lock_enabled_switch_->publish_state(enabled);
-        this->advanced_config_update_ = true;
+    else if(config == "fob_action_3")
+    {
+        const uint8_t action = this->fob_action_to_int(value);
+        if(action != 99)
+        {
+            cmd_result = this->nuki_lock_.setFobAction(3, action);
+        }
     }
-    #endif
-}
 
-void NukiLockComponent::set_night_mode_auto_unlock_disabled(bool disable) {
-    
-    Nuki::CmdResult cmdResult = this->nuki_lock_.disableNightModeAutoUnlock(disable);
-
-    #ifdef USE_SWITCH
-    if (cmdResult == Nuki::CmdResult::Success && this->night_mode_auto_unlock_disabled_switch_ != nullptr) {
-        this->night_mode_auto_unlock_disabled_switch_->publish_state(disable);
-        this->advanced_config_update_ = true;
+    if(cmd_result == Nuki::CmdResult::Success)
+    {
+        if(config == "single_button_press_action")
+        {
+            if (this->single_button_press_action_select_ != nullptr) this->single_button_press_action_select_->publish_state(value);
+        } 
+        else if(config == "double_button_press_action")
+        {
+            if (this->double_button_press_action_select_ != nullptr) this->double_button_press_action_select_->publish_state(value);
+        } 
+        else if(config == "fob_action_1")
+        {
+            if (this->fob_action_1_select_ != nullptr) this->fob_action_1_select_->publish_state(value);
+        } 
+        else if(config == "fob_action_2")
+        {
+            if (this->fob_action_2_select_ != nullptr) this->fob_action_2_select_->publish_state(value);
+        } 
+        else if(config == "fob_action_3")
+        {
+            if (this->fob_action_3_select_ != nullptr) this->fob_action_3_select_->publish_state(value);
+        } 
+        
+        this->config_update_ = !is_advanced;
+        this->advanced_config_update_ = is_advanced;
     }
-    #endif
 }
+#endif
 
-void NukiLockComponent::set_night_mode_immediate_lock_on_start(bool enabled) {
-    
-    Nuki::CmdResult cmdResult = this->nuki_lock_.enableNightModeImmediateLockOnStart(enabled);
+#ifdef USE_SWITCH
+void NukiLockComponent::set_config_switch(std::string config, bool value) {
 
-    #ifdef USE_SWITCH
-    if (cmdResult == Nuki::CmdResult::Success && this->night_mode_immediate_lock_on_start_switch_ != nullptr) {
-        this->night_mode_immediate_lock_on_start_switch_->publish_state(enabled);
-        this->advanced_config_update_ = true;
+    Nuki::CmdResult cmd_result = (Nuki::CmdResult)-1;
+    bool is_advanced = false;
+
+    // Update Config
+    if(config == "auto_unlatch_enabled")
+    {
+        cmd_result = this->nuki_lock_.enableAutoUnlatch(value);
     }
-    #endif
-}
-
-void NukiLockComponent::set_auto_lock_enabled(bool enabled) {
-    
-    Nuki::CmdResult cmdResult = this->nuki_lock_.enableAutoLock(enabled);
-
-    #ifdef USE_SWITCH
-    if (cmdResult == Nuki::CmdResult::Success && this->auto_lock_enabled_switch_ != nullptr) {
-        this->auto_lock_enabled_switch_->publish_state(enabled);
-        this->advanced_config_update_ = true;
+    else if(config == "button_enabled")
+    {
+        cmd_result = this->nuki_lock_.enableButton(value);
     }
-    #endif
-}
-
-void NukiLockComponent::set_auto_unlock_disabled(bool disabled) {
-    
-    Nuki::CmdResult cmdResult = this->nuki_lock_.disableAutoUnlock(disabled);
-
-    #ifdef USE_SWITCH
-    if (cmdResult == Nuki::CmdResult::Success && this->auto_unlock_disabled_switch_ != nullptr) {
-        this->auto_unlock_disabled_switch_->publish_state(disabled);
-        this->advanced_config_update_ = true;
+    else if(config == "led_enabled")
+    {
+        cmd_result = this->nuki_lock_.enableLedFlash(value);
     }
-    #endif
-}
-
-void NukiLockComponent::set_immediate_auto_lock_enabled(bool enabled) {
-    
-    Nuki::CmdResult cmdResult = this->nuki_lock_.enableImmediateAutoLock(enabled);
-
-    #ifdef USE_SWITCH
-    if (cmdResult == Nuki::CmdResult::Success && this->immediate_auto_lock_enabled_switch_ != nullptr) {
-        this->immediate_auto_lock_enabled_switch_->publish_state(enabled);
-        this->advanced_config_update_ = true;
+    else if(config == "nightmode_enabled")
+    {
+        cmd_result = this->nuki_lock_.enableNightMode(value);
+        is_advanced = true;
     }
-    #endif
-}
-
-void NukiLockComponent::set_auto_update_enabled(bool enabled) {
-    
-    Nuki::CmdResult cmdResult = this->nuki_lock_.enableAutoUpdate(enabled);
-
-    #ifdef USE_SWITCH
-    if (cmdResult == Nuki::CmdResult::Success && this->auto_update_enabled_switch_ != nullptr) {
-        this->auto_update_enabled_switch_->publish_state(enabled);
-        this->advanced_config_update_ = true;
+    else if(config == "night_mode_auto_lock_enabled")
+    {
+        cmd_result = this->nuki_lock_.enableNightModeAutoLock(value);
+        is_advanced = true;
     }
-    #endif
-}
-
-void NukiLockComponent::set_led_brightness(float value) {
-    
-    Nuki::CmdResult cmdResult = this->nuki_lock_.setLedBrightness(static_cast<uint8_t>(value));
-
-    #ifdef USE_NUMBER
-    if (cmdResult == Nuki::CmdResult::Success && this->led_brightness_number_ != nullptr) {
-        this->led_brightness_number_->publish_state(value);
-        this->config_update_ = true;
+    else if(config == "night_mode_auto_unlock_disabled")
+    {
+        cmd_result = this->nuki_lock_.disableNightModeAutoUnlock(value);
+        is_advanced = true;
     }
-    #endif
+    else if(config == "night_mode_immediate_lock_on_start")
+    {
+        cmd_result = this->nuki_lock_.enableNightModeImmediateLockOnStart(value);
+        is_advanced = true;
+    }
+    else if(config == "auto_lock_enabled")
+    {
+        cmd_result = this->nuki_lock_.enableAutoLock(value);
+        is_advanced = true;
+    }
+    else if(config == "auto_unlock_disabled")
+    {
+        cmd_result = this->nuki_lock_.disableAutoUnlock(value);
+        is_advanced = true;
+    }
+    else if(config == "immediate_auto_lock_enabled")
+    {
+        cmd_result = this->nuki_lock_.enableImmediateAutoLock(value);
+        is_advanced = true;
+    }
+    else if(config == "auto_update_enabled")
+    {
+        cmd_result = this->nuki_lock_.enableAutoUpdate(value);
+        is_advanced = true;
+    }
+
+    if(cmd_result == Nuki::CmdResult::Success)
+    {
+        if(config == "auto_unlatch_enabled")
+        {
+            if (this->auto_unlatch_enabled_switch_ != nullptr) this->auto_unlatch_enabled_switch_->publish_state(value);
+        }
+        else if(config == "button_enabled")
+        {
+            if (this->button_enabled_switch_ != nullptr) this->button_enabled_switch_->publish_state(value);
+        }        
+        else if(config == "led_enabled")
+        {
+            if (this->led_enabled_switch_ != nullptr) this->led_enabled_switch_->publish_state(value);
+        }        
+        else if(config == "nightmode_enabled")
+        {
+            if (this->nightmode_enabled_switch_ != nullptr) this->nightmode_enabled_switch_->publish_state(value);
+        }        
+        else if(config == "night_mode_auto_lock_enabled")
+        {
+            if (this->night_mode_auto_lock_enabled_switch_ != nullptr) this->night_mode_auto_lock_enabled_switch_->publish_state(value);
+        }        
+        else if(config == "night_mode_auto_unlock_disabled")
+        {
+            if (this->night_mode_auto_unlock_disabled_switch_ != nullptr) this->night_mode_auto_unlock_disabled_switch_->publish_state(value);
+        }        
+        else if(config == "night_mode_immediate_lock_on_start")
+        {
+            if (this->night_mode_immediate_lock_on_start_switch_ != nullptr) this->night_mode_immediate_lock_on_start_switch_->publish_state(value);
+        }        
+        else if(config == "auto_lock_enabled")
+        {
+            if (this->auto_lock_enabled_switch_ != nullptr) this->auto_lock_enabled_switch_->publish_state(value);
+        }        
+        else if(config == "auto_unlock_disabled")
+        {
+            if (this->auto_unlock_disabled_switch_ != nullptr) this->auto_unlock_disabled_switch_->publish_state(value);
+        }        
+        else if(config == "immediate_auto_lock_enabled")
+        {
+            if (this->immediate_auto_lock_enabled_switch_ != nullptr) this->immediate_auto_lock_enabled_switch_->publish_state(value);
+        }        
+        else if(config == "auto_update_enabled")
+        {
+            if (this->auto_update_enabled_switch_ != nullptr) this->auto_update_enabled_switch_->publish_state(value);
+        }        
+        
+        this->config_update_ = !is_advanced;
+        this->advanced_config_update_ = is_advanced;
+    }
 }
+#endif
+#ifdef USE_NUMBER
+void NukiLockComponent::set_config_number(std::string config, float value) {
+
+    Nuki::CmdResult cmd_result = (Nuki::CmdResult)-1;
+    bool is_advanced = false;
+
+    // Update Config
+    if(config == "led_brightness")
+    {
+        cmd_result = this->nuki_lock_.setLedBrightness(value);
+    }
+
+    if(cmd_result == Nuki::CmdResult::Success)
+    {
+        if(config == "led_brightness")
+        {
+            if (this->led_brightness_number_ != nullptr) this->led_brightness_number_->publish_state(value);
+        } 
+        
+        this->config_update_ = !is_advanced;
+        this->advanced_config_update_ = is_advanced;
+    }
+}
+#endif
 
 #ifdef USE_BUTTON
 void NukiLockUnpairButton::press_action() {
@@ -1183,19 +1172,19 @@ void NukiLockUnpairButton::press_action() {
 #endif
 #ifdef USE_SELECT
 void NukiLockSingleButtonPressActionSelect::control(const std::string &action) {
-    this->parent_->set_single_button_press_action(action);
+    this->parent_->set_config_select("single_button_press_action", action);
 }
 void NukiLockDoubleButtonPressActionSelect::control(const std::string &action) {
-    this->parent_->set_double_button_press_action(action);
+    this->parent_->set_config_select("double_button_press_action", action);
 }
 void NukiLockFobAction1Select::control(const std::string &action) {
-    this->parent_->set_fob_action_1(action);
+    this->parent_->set_config_select("fob_action_1", action);
 }
 void NukiLockFobAction2Select::control(const std::string &action) {
-    this->parent_->set_fob_action_2(action);
+    this->parent_->set_config_select("fob_action_2", action);
 }
 void NukiLockFobAction3Select::control(const std::string &action) {
-    this->parent_->set_fob_action_3(action);
+    this->parent_->set_config_select("fob_action_3", action);
 }
 #endif
 #ifdef USE_SWITCH
@@ -1204,52 +1193,52 @@ void NukiLockPairingModeSwitch::write_state(bool state) {
 }
 
 void NukiLockAutoUnlatchEnabledSwitch::write_state(bool state) {
-    this->parent_->set_auto_unlatch_enabled(state);
+    this->parent_->set_config_switch("auto_unlatch_enabled", state);
 }
 
 void NukiLockButtonEnabledSwitch::write_state(bool state) {
-    this->parent_->set_button_enabled(state);
+    this->parent_->set_config_switch("button_enabled", state);
 }
 
 void NukiLockLedEnabledSwitch::write_state(bool state) {
-    this->parent_->set_led_enabled(state);
+    this->parent_->set_config_switch("led_enabled", state);
 }
 
 void NukiLockNightModeEnabledSwitch::write_state(bool state) {
-    this->parent_->set_nightmode_enabled(state);
+    this->parent_->set_config_switch("nightmode_enabled", state);
 }
 
 void NukiLockNightModeAutoLockEnabledSwitch::write_state(bool state) {
-    this->parent_->set_night_mode_auto_lock_enabled(state);
+    this->parent_->set_config_switch("night_mode_auto_lock_enabled", state);
 }
 
 void NukiLockNightModeAutoUnlockDisabledSwitch::write_state(bool state) {
-    this->parent_->set_night_mode_auto_unlock_disabled(state);
+    this->parent_->set_config_switch("night_mode_auto_unlock_disabled", state);
 }
 
 void NukiLockNightModeImmediateLockOnStartEnabledSwitch::write_state(bool state) {
-    this->parent_->set_night_mode_immediate_lock_on_start(state);
+    this->parent_->set_config_switch("night_mode_immediate_lock_on_start", state);
 }
 
 void NukiLockAutoLockEnabledSwitch::write_state(bool state) {
-    this->parent_->set_auto_lock_enabled(state);
+    this->parent_->set_config_switch("auto_lock_enabled", state);
 }
 
 void NukiLockAutoUnlockDisabledSwitch::write_state(bool state) {
-    this->parent_->set_auto_unlock_disabled(state);
+    this->parent_->set_config_switch("auto_unlock_disabled", state);
 }
 
 void NukiLockImmediateAutoLockEnabledSwitch::write_state(bool state) {
-    this->parent_->set_immediate_auto_lock_enabled(state);
+    this->parent_->set_config_switch("immediate_auto_lock_enabled", state);
 }
 
 void NukiLockAutoUpdateEnabledSwitch::write_state(bool state) {
-    this->parent_->set_auto_update_enabled(state);
+    this->parent_->set_config_switch("auto_update_enabled", state);
 }
 #endif
 #ifdef USE_NUMBER
 void NukiLockLedBrightnessNumber::control(float value) {
-    this->parent_->set_led_brightness(value);
+    this->parent_->set_config_number("led_brightness", value);
 }
 #endif
 

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -573,6 +573,8 @@ void NukiLockComponent::setup() {
         this->config_update_ = true;
         this->advanced_config_update_ = true;
 
+        // First auth data request, then every 2nd time
+        this->auth_data_required_ = true;
         this->auth_data_update_ = true;
 
         ESP_LOGI(TAG, "%s Nuki paired", this->deviceName_);
@@ -929,7 +931,16 @@ void NukiLockComponent::notify(Nuki::EventType event_type) {
     this->status_update_ = true;
     this->config_update_ = true;
     this->advanced_config_update_ = true;
-    this->auth_data_update_ = true;
+    
+    // Request Auth Data on every second notify, otherwise just event logs
+    // Event logs are always requested after Auth Data requests
+    this->auth_data_required_ = !this->auth_data_required_;
+    if(this->auth_data_required_) {
+        this->auth_data_update_ = true;
+    } else {
+        this->event_log_update_ = true;
+    }
+
     ESP_LOGI(TAG, "event notified %d", event_type);
 }
 

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -383,11 +383,6 @@ void NukiLockComponent::process_log_entries(const std::list<NukiLock::LogEntry>&
             }
         }
 
-        #ifdef USE_TEXT_SENSOR
-        if (this->last_unlock_user_text_sensor_ != nullptr)
-            this->last_unlock_user_text_sensor_->publish_state(this->auth_name_);
-        #endif
-
         if (strcmp(event_, "esphome.none") != 0)
         {
             std::map<std::string, std::string> event_data;
@@ -497,6 +492,11 @@ void NukiLockComponent::process_log_entries(const std::list<NukiLock::LogEntry>&
             }
         }
     }
+
+    #ifdef USE_TEXT_SENSOR
+    if (this->last_unlock_user_text_sensor_ != nullptr)
+        this->last_unlock_user_text_sensor_->publish_state(this->auth_name_);
+    #endif
 }
 
 bool NukiLockComponent::execute_lock_action(NukiLock::LockAction lock_action) {

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -54,13 +54,13 @@ std::string NukiLockComponent::nuki_doorsensor_to_string(Nuki::DoorSensorState n
 
 NukiLock::ButtonPressAction NukiLockComponent::nuki_button_press_action_to_enum(std::string str)
 {
-    if (str == "No Action") return NoAction;
-    if (str == "Intelligent") return Intelligent;
-    if (str == "Unlock") return Unlock;
-    if (str == "Lock") return Lock;
-    if (str == "Unlatch") return Unlatch;
-    if (str == "Lock n Go") return LockNgo;
-    if (str == "Show Status") return ShowStatus;
+    if (str == "No Action") return NukiLock::ButtonPressAction::NoAction;
+    if (str == "Intelligent") return NukiLock::ButtonPressAction::Intelligent;
+    if (str == "Unlock") return NukiLock::ButtonPressAction::Unlock;
+    if (str == "Lock") return NukiLock::ButtonPressAction::Lock;
+    if (str == "Unlatch") return NukiLock::ButtonPressAction::Unlatch;
+    if (str == "Lock n Go") return NukiLock::ButtonPressAction::LockNgo;
+    if (str == "Show Status") return NukiLock::ButtonPressAction::ShowStatus;
     return (NukiLock::ButtonPressAction)0xff;
 }
 

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -239,7 +239,7 @@ void NukiLockComponent::update_auth_data()
     while(retryCount < 3)
     {
         ESP_LOGD(TAG, "Retrieve Auth Data");
-        confReqResult = this->nuki_lock_.retrieveAuthorizationEntries(0, 10);
+        confReqResult = this->nuki_lock_.retrieveAuthorizationEntries(0, MAX_AUTH_DATA_ENTRIES);
 
         if(confReqResult != Nuki::CmdResult::Success)
         {
@@ -263,9 +263,9 @@ void NukiLockComponent::update_auth_data()
         return a.authId < b.authId;
     });
 
-    if(authEntries.size() > 20)
+    if(authEntries.size() > MAX_AUTH_DATA_ENTRIES)
     {
-        authEntries.resize(20);
+        authEntries.resize(MAX_AUTH_DATA_ENTRIES);
     }
 
     for(const auto& entry : authEntries)
@@ -284,7 +284,7 @@ void NukiLockComponent::update_event_logs()
     while(retryCount < 3)
     {
         ESP_LOGD(TAG, "Retrieve Event Logs");
-        confReqResult = this->nuki_lock_.retrieveLogEntries(0, 10, 1, false);
+        confReqResult = this->nuki_lock_.retrieveLogEntries(0, MAX_EVENT_LOG_ENTRIES, 1, false);
 
         if(confReqResult != Nuki::CmdResult::Success)
         {
@@ -303,9 +303,9 @@ void NukiLockComponent::update_event_logs()
     std::list<NukiLock::LogEntry> log;
     this->nuki_lock_.getLogEntries(&log);
 
-    if(log.size() > 3)
+    if(log.size() > MAX_EVENT_LOG_ENTRIES)
     {
-        log.resize(3);
+        log.resize(MAX_EVENT_LOG_ENTRIES);
     }
 
     log.sort([](const NukiLock::LogEntry& a, const NukiLock::LogEntry& b)

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -80,6 +80,26 @@ const char* NukiLockComponent::nuki_button_press_action_to_string(NukiLock::Butt
     }
 }
 
+uint8_t NukiLockComponent::fob_action_to_int(std::string str)
+{
+    if(str == "No Action") return 0;
+    if(str == "Unlock") return 1;
+    if(str == "Lock") return 2;
+    if(str == "Lock n Go") return 3;
+    if(str == "Intelligent") return 4;
+    return 99;
+}
+
+std::string NukiLockComponent::fob_action_to_string(uint8_t action)
+{
+    if(action == 0) return "No Action";
+    if(action == 1) return "Unlock";
+    if(action == 2) return "Lock";
+    if(action == 3) return "Lock n Go";
+    if(action == 4) return "Intelligent";
+    return 99;
+}
+
 void NukiLockComponent::update_status()
 {
     this->status_update_ = false;
@@ -172,6 +192,14 @@ void NukiLockComponent::update_config() {
         if (this->led_brightness_number_ != nullptr)
             this->led_brightness_number_->publish_state(config.ledBrightness);
         #endif
+        #ifdef USE_SELECT
+        if (this->fob_action_1_select_ != nullptr)
+            this->fob_action_1_select_->publish_state(this->fob_action_to_string(config.fobAction1));
+        if (this->fob_action_2_select_ != nullptr)
+            this->fob_action_2_select_->publish_state(this->fob_action_to_string(config.fobAction2));
+        if (this->fob_action_3_select_ != nullptr)
+            this->fob_action_3_select_->publish_state(this->fob_action_to_string(config.fobAction3));
+        #endif
 
     } else {
         ESP_LOGE(TAG, "requestConfig has resulted in %s (%d)", confReqResultAsString, confReqResult);
@@ -215,7 +243,6 @@ void NukiLockComponent::update_advanced_config() {
         if (this->auto_update_enabled_switch_ != nullptr)
             this->auto_update_enabled_switch_->publish_state(advanced_config.autoUpdateEnabled);
         #endif
-
         #ifdef USE_SELECT
         if (this->single_button_press_action_select_ != nullptr)
             this->single_button_press_action_select_->publish_state(this->nuki_button_press_action_to_string(advanced_config.singleButtonPressAction));
@@ -929,6 +956,57 @@ void NukiLockComponent::set_double_button_press_action(const std::string &action
     #endif
 }
 
+void NukiLockComponent::set_fob_action_1(const std::string &action) {
+
+    const uint8_t fob_action = this->fob_action_to_int(jsonchar);
+
+    if(fob_action != 99)
+    {
+        Nuki::CmdResult cmdResult = this->nuki_lock_.setFobAction(3, fob_action);
+
+        #ifdef USE_SELECT
+        if (cmdResult == Nuki::CmdResult::Success && this->fob_action_1_select_ != nullptr) {
+            this->fob_action_1_select_->publish_state(action);
+            this->config_update_ = true;
+        }
+        #endif
+    }
+}
+
+void NukiLockComponent::set_fob_action_2(const std::string &action) {
+
+    const uint8_t fob_action = this->fob_action_to_int(jsonchar);
+
+    if(fob_action != 99)
+    {
+        Nuki::CmdResult cmdResult = this->nuki_lock_.setFobAction(3, fob_action);
+
+        #ifdef USE_SELECT
+        if (cmdResult == Nuki::CmdResult::Success && this->fob_action_2_select_ != nullptr) {
+            this->fob_action_2_select_->publish_state(action);
+            this->config_update_ = true;
+        }
+        #endif
+    }
+}
+
+void NukiLockComponent::set_fob_action_3(const std::string &action) {
+
+    const uint8_t fob_action = this->fob_action_to_int(jsonchar);
+
+    if(fob_action != 99)
+    {
+        Nuki::CmdResult cmdResult = this->nuki_lock_.setFobAction(3, fob_action);
+
+        #ifdef USE_SELECT
+        if (cmdResult == Nuki::CmdResult::Success && this->fob_action_3_select_ != nullptr) {
+            this->fob_action_3_select_->publish_state(action);
+            this->config_update_ = true;
+        }
+        #endif
+    }
+}
+
 void NukiLockComponent::set_pairing_mode(bool enabled) {
     this->pairing_mode_ = enabled;
 
@@ -1109,6 +1187,15 @@ void NukiLockSingleButtonPressActionSelect::control(const std::string &action) {
 }
 void NukiLockDoubleButtonPressActionSelect::control(const std::string &action) {
     this->parent_->set_double_button_press_action(action);
+}
+void NukiLockFobAction1Select::control(const std::string &action) {
+    this->parent_->set_fob_action_1(action);
+}
+void NukiLockFobAction2Select::control(const std::string &action) {
+    this->parent_->set_fob_action_2(action);
+}
+void NukiLockFobAction3Select::control(const std::string &action) {
+    this->parent_->set_fob_action_3(action);
 }
 #endif
 #ifdef USE_SWITCH

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -323,7 +323,6 @@ void NukiLockComponent::processLogEntries(const std::list<NukiLock::LogEntry>& l
     char str[50];
     char authName[33];
     uint32_t authIndex = 0;
-    
 
     for(const auto& log : logEntries)
     {
@@ -448,15 +447,20 @@ void NukiLockComponent::processLogEntries(const std::list<NukiLock::LogEntry>& l
                 }
                 break;
         }
-
-        /*if(log.index > _lastRollingLog)
+        
+        // Send as Home Assistant Event
+        if(log.index > this->last_rolling_log_id)
         {
-            _lastRollingLog = log.index;
-            serializeJson(entry, _buffer, _bufferSize);
-            publishString(mqtt_topic_lock_log_rolling, _buffer, true);
-            publishInt(mqtt_topic_lock_log_rolling_last, log.index, true);
-        }*/
+            this->last_rolling_log_id = log.index;
+
+            // TODO
+        }
     }
+
+    #ifdef USE_TEXT_SENSOR
+    if (this->last_unlock_user_text_sensor_ != nullptr)
+        this->last_unlock_user_text_sensor_->publish_state(this->auth_name_);
+    #endif
 }
 
 bool NukiLockComponent::executeLockAction(NukiLock::LockAction lockAction) {
@@ -845,6 +849,7 @@ void NukiLockComponent::dump_config() {
     #endif
     #ifdef USE_TEXT_SENSOR
     LOG_TEXT_SENSOR(TAG, "Door Sensor State", this->door_sensor_state_text_sensor_);
+    LOG_TEXT_SENSOR(TAG, "Last Unlock User", this->last_unlock_user_text_sensor_);
     #endif
     #ifdef USE_SENSOR
     LOG_SENSOR(TAG, "Battery Level", this->battery_level_sensor_);

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -52,6 +52,10 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
     #ifdef USE_NUMBER
     SUB_NUMBER(led_brightness)
     #endif
+    #ifdef USE_SELECT
+    SUB_SELECT(single_button_press_action)
+    SUB_SELECT(double_button_press_action)
+    #endif
     #ifdef USE_BUTTON
     SUB_BUTTON(unpair)
     #endif
@@ -60,6 +64,14 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
     SUB_SWITCH(button_enabled)
     SUB_SWITCH(auto_unlatch_enabled)
     SUB_SWITCH(led_enabled)
+    SUB_SWITCH(nightmode_enabled)
+    SUB_SWITCH(night_mode_auto_lock_enabled)
+    SUB_SWITCH(night_mode_auto_unlock_disabled)
+    SUB_SWITCH(night_mode_immediate_lock_on_start)
+    SUB_SWITCH(auto_lock_enabled)
+    SUB_SWITCH(auto_unlock_disabled)
+    SUB_SWITCH(immediate_auto_lock_enabled)
+    SUB_SWITCH(auto_update_enabled)
     #endif
 
     static const uint8_t BLE_CONNECT_TIMEOUT_SEC = 3;
@@ -102,12 +114,28 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
         bool nuki_doorsensor_to_binary(Nuki::DoorSensorState);
         std::string nuki_doorsensor_to_string(Nuki::DoorSensorState nukiDoorSensorState);
 
+        NukiLock::ButtonPressAction nuki_button_press_action_to_enum(std::string str);
+        const char* nuki_button_press_action_to_string(NukiLock::ButtonPressAction action);
+
         void unpair();
+
         void set_pairing_mode(bool enabled);
         void set_auto_unlatch_enabled(bool enabled);
         void set_button_enabled(bool enabled);
         void set_led_enabled(bool enabled);
+        void set_nightmode_enabled(bool enabled);
+        void set_night_mode_auto_lock_enabled(bool enabled);
+        void set_night_mode_auto_unlock_disabled(bool disabled);
+        void set_night_mode_immediate_lock_on_start(bool enabled);
+        void set_auto_lock_enabled(bool enabled);
+        void set_auto_unlock_disabled(bool disabled);
+        void set_immediate_auto_lock_enabled(bool enabled);
+        void set_auto_update_enabled(bool enabled);
+
         void set_led_brightness(float value);
+
+        void set_single_button_press_action(const std::string &action);
+        void set_double_button_press_action(const std::string &action);
 
     protected:
         void control(const lock::LockCall &call) override;
@@ -115,6 +143,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
 
         void update_status();
         void update_config();
+        void update_advanced_config();
         bool executeLockAction(NukiLock::LockAction lockAction);
 
         BleScanner::Scanner scanner_;
@@ -128,6 +157,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
 
         bool status_update_;
         bool config_update_;
+        bool advanced_config_update_;
         bool open_latch_;
         bool lock_n_go_;
 
@@ -207,52 +237,116 @@ class NukiLockUnpairButton : public button::Button, public Parented<NukiLockComp
 };
 #endif
 
+#ifdef USE_SELECT
+class NukiLockSingleButtonPressActionSelect : public select::Select, public Parented<NukiLockComponent> {
+    public:
+        NukiLockSingleButtonPressActionSelect() = default;
+    protected:
+        void control(const std::string &value) override;
+};
+
+class NukiLockDoubleButtonPressActionSelect : public select::Select, public Parented<NukiLockComponent> {
+    public:
+        NukiLockDoubleButtonPressActionSelect() = default;
+    protected:
+        void control(const std::string &value) override;
+};
+#endif
+
 #ifdef USE_SWITCH
 class NukiLockPairingModeSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
     public:
         NukiLockPairingModeSwitch() = default;
-        Trigger<> *get_turn_on_trigger() const;
-        Trigger<> *get_turn_off_trigger() const;
     protected:
         void write_state(bool state) override;
-        Trigger<> *turn_on_trigger_;
-        Trigger<> *turn_off_trigger_;
 };
 
 class NukiLockAutoUnlatchEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
    public:
       NukiLockAutoUnlatchEnabledSwitch() = default;
-      Trigger<> *get_turn_on_trigger() const;
-      Trigger<> *get_turn_off_trigger() const;
 
    protected:
       void write_state(bool state) override;
-      Trigger<> *turn_on_trigger_;
-      Trigger<> *turn_off_trigger_;
 };
 
 class NukiLockButtonEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
    public:
       NukiLockButtonEnabledSwitch() = default;
-      Trigger<> *get_turn_on_trigger() const;
-      Trigger<> *get_turn_off_trigger() const;
 
    protected:
       void write_state(bool state) override;
-      Trigger<> *turn_on_trigger_;
-      Trigger<> *turn_off_trigger_;
 };
 
 class NukiLockLedEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
     public:
         NukiLockLedEnabledSwitch() = default;
-        Trigger<> *get_turn_on_trigger() const;
-        Trigger<> *get_turn_off_trigger() const;
 
     protected:
         void write_state(bool state) override;
-        Trigger<> *turn_on_trigger_;
-        Trigger<> *turn_off_trigger_;
+};
+
+class NukiLockNightModeEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
+    public:
+        NukiLockNightModeEnabledSwitch() = default;
+
+    protected:
+        void write_state(bool state) override;
+};
+
+class NukiLockNightModeAutoLockEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
+    public:
+        NukiLockNightModeAutoLockEnabledSwitch() = default;
+
+    protected:
+        void write_state(bool state) override;
+};
+
+class NukiLockNightModeAutoUnlockDisabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
+    public:
+        NukiLockNightModeAutoUnlockDisabledSwitch() = default;
+
+    protected:
+        void write_state(bool state) override;
+};
+
+class NukiLockNightModeImmediateLockOnStartEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
+    public:
+        NukiLockNightModeImmediateLockOnStartEnabledSwitch() = default;
+
+    protected:
+        void write_state(bool state) override;
+};
+
+class NukiLockAutoLockEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
+    public:
+        NukiLockAutoLockEnabledSwitch() = default;
+
+    protected:
+        void write_state(bool state) override;
+};
+
+class NukiLockAutoUnlockDisabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
+    public:
+        NukiLockAutoUnlockDisabledSwitch() = default;
+
+    protected:
+        void write_state(bool state) override;
+};
+
+class NukiLockImmediateAutoLockEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
+    public:
+        NukiLockImmediateAutoLockEnabledSwitch() = default;
+
+    protected:
+        void write_state(bool state) override;
+};
+
+class NukiLockAutoUpdateEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
+    public:
+        NukiLockAutoUpdateEnabledSwitch() = default;
+
+    protected:
+        void write_state(bool state) override;
 };
 #endif
 

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -56,6 +56,9 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
     #ifdef USE_SELECT
     SUB_SELECT(single_button_press_action)
     SUB_SELECT(double_button_press_action)
+    SUB_SELECT(fob_action_1)
+    SUB_SELECT(fob_action_2)
+    SUB_SELECT(fob_action_3)
     #endif
     #ifdef USE_BUTTON
     SUB_BUTTON(unpair)
@@ -121,6 +124,9 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
         bool nuki_doorsensor_to_binary(Nuki::DoorSensorState);
         std::string nuki_doorsensor_to_string(Nuki::DoorSensorState nukiDoorSensorState);
 
+        uint8_t fob_action_to_int(std::string str);
+        std::string fob_action_to_string(uint_8_t action);
+
         NukiLock::ButtonPressAction nuki_button_press_action_to_enum(std::string str);
         const char* nuki_button_press_action_to_string(NukiLock::ButtonPressAction action);
 
@@ -143,6 +149,9 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
 
         void set_single_button_press_action(const std::string &action);
         void set_double_button_press_action(const std::string &action);
+        void set_fob_action_1(const std::string &action);
+        void set_fob_action_2(const std::string &action);
+        void set_fob_action_3(const std::string &action);
 
     protected:
         void control(const lock::LockCall &call) override;
@@ -269,6 +278,26 @@ class NukiLockSingleButtonPressActionSelect : public select::Select, public Pare
 class NukiLockDoubleButtonPressActionSelect : public select::Select, public Parented<NukiLockComponent> {
     public:
         NukiLockDoubleButtonPressActionSelect() = default;
+    protected:
+        void control(const std::string &value) override;
+};
+
+class NukiLockFobAction1Select : public select::Select, public Parented<NukiLockComponent> {
+    public:
+        NukiLockFobAction1Select() = default;
+    protected:
+        void control(const std::string &value) override;
+};
+
+class NukiLockFobAction2Select : public select::Select, public Parented<NukiLockComponent> {
+    public:
+        NukiLockFobAction2Select() = default;
+    protected:
+        void control(const std::string &value) override;
+};
+class NukiLockFobAction3Select : public select::Select, public Parented<NukiLockComponent> {
+    public:
+        NukiLockFobAction3Select() = default;
     protected:
         void control(const std::string &value) override;
 };

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -175,6 +175,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
         bool advanced_config_update_;
         bool auth_data_update_;
         bool event_log_update_;
+        bool auth_data_required_;
         bool open_latch_;
         bool lock_n_go_;
 

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -125,33 +125,23 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
         std::string nuki_doorsensor_to_string(Nuki::DoorSensorState nukiDoorSensorState);
 
         uint8_t fob_action_to_int(std::string str);
-        std::string fob_action_to_string(uint_8_t action);
+        std::string fob_action_to_string(uint8_t action);
 
         NukiLock::ButtonPressAction nuki_button_press_action_to_enum(std::string str);
         const char* nuki_button_press_action_to_string(NukiLock::ButtonPressAction action);
 
         void unpair();
-
         void set_pairing_mode(bool enabled);
-        void set_auto_unlatch_enabled(bool enabled);
-        void set_button_enabled(bool enabled);
-        void set_led_enabled(bool enabled);
-        void set_nightmode_enabled(bool enabled);
-        void set_night_mode_auto_lock_enabled(bool enabled);
-        void set_night_mode_auto_unlock_disabled(bool disabled);
-        void set_night_mode_immediate_lock_on_start(bool enabled);
-        void set_auto_lock_enabled(bool enabled);
-        void set_auto_unlock_disabled(bool disabled);
-        void set_immediate_auto_lock_enabled(bool enabled);
-        void set_auto_update_enabled(bool enabled);
 
-        void set_led_brightness(float value);
-
-        void set_single_button_press_action(const std::string &action);
-        void set_double_button_press_action(const std::string &action);
-        void set_fob_action_1(const std::string &action);
-        void set_fob_action_2(const std::string &action);
-        void set_fob_action_3(const std::string &action);
+        #ifdef USE_NUMBER
+        void set_config_number(std::string config, float value);
+        #endif
+        #ifdef USE_SWITCH
+        void set_config_switch(std::string config, bool value);
+        #endif
+        #ifdef USE_SELECT
+        void set_config_select(std::string config, const std::string &value);
+        #endif
 
     protected:
         void control(const lock::LockCall &call) override;

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -48,6 +48,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
     #endif
     #ifdef USE_TEXT_SENSOR
     SUB_TEXT_SENSOR(door_sensor_state)
+    SUB_TEXT_SENSOR(last_unlock_user)
     #endif
     #ifdef USE_NUMBER
     SUB_NUMBER(led_brightness)
@@ -177,6 +178,8 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
         uint16_t pairing_mode_timeout_ = 0;
         bool pairing_mode_ = false;
         uint32_t pairing_mode_timer_ = 0;
+
+        uint32_t last_rolling_log_id = 0;
 
     private:
         NukiLock::NukiLock nukiLock_;

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -1,13 +1,30 @@
 #pragma once
 
 #include "esphome/core/component.h"
-#include "esphome/components/lock/lock.h"
-#include "esphome/components/button/button.h"
-#include "esphome/components/switch/switch.h"
-#include "esphome/components/binary_sensor/binary_sensor.h"
-#include "esphome/components/sensor/sensor.h"
-#include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/api/custom_api_device.h"
+#include "esphome/components/lock/lock.h"
+
+#ifdef USE_BUTTON
+#include "esphome/components/button/button.h"
+#endif
+#ifdef USE_SWITCH
+#include "esphome/components/switch/switch.h"
+#endif
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+#ifdef USE_SENSOR
+#include "esphome/components/sensor/sensor.h"
+#endif
+#ifdef USE_TEXT_SENSOR
+#include "esphome/components/text_sensor/text_sensor.h"
+#endif
+#ifdef USE_NUMBER
+#include "esphome/components/number/number.h"
+#endif
+#ifdef USE_SELECT
+#include "esphome/components/select/select.h"
+#endif
 
 #include "NukiLock.h"
 #include "NukiConstants.h"
@@ -19,6 +36,31 @@ namespace nuki_lock {
 static const char *TAG = "nukilock.lock";
 
 class NukiLockComponent : public lock::Lock, public PollingComponent, public api::CustomAPIDevice, public Nuki::SmartlockEventHandler {
+    
+    #ifdef USE_BINARY_SENSOR
+    SUB_BINARY_SENSOR(is_connected)
+    SUB_BINARY_SENSOR(is_paired)
+    SUB_BINARY_SENSOR(battery_critical)
+    SUB_BINARY_SENSOR(door_sensor)
+    #endif
+    #ifdef USE_SENSOR
+    SUB_SENSOR(battery_level)
+    #endif
+    #ifdef USE_TEXT_SENSOR
+    SUB_TEXT_SENSOR(door_sensor_state)
+    #endif
+    #ifdef USE_NUMBER
+    SUB_NUMBER(led_brightness)
+    #endif
+    #ifdef USE_BUTTON
+    SUB_BUTTON(unpair)
+    #endif
+    #ifdef USE_SWITCH
+    SUB_SWITCH(pairing_mode)
+    SUB_SWITCH(button_enabled)
+    SUB_SWITCH(led_enabled)
+    #endif
+
     static const uint8_t BLE_CONNECT_TIMEOUT_SEC = 3;
     static const uint8_t BLE_CONNECT_TIMEOUT_RETRIES = 1;
     static const uint8_t MAX_ACTION_ATTEMPTS = 5;
@@ -40,54 +82,38 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
 
         void setup() override;
         void update() override;
+        void dump_config() override;
+        void notify(Nuki::EventType eventType) override;
+        float get_setup_priority() const override { return setup_priority::HARDWARE - 1.0f; }
 
-        void set_is_connected(binary_sensor::BinarySensor *is_connected) { this->is_connected_ = is_connected; }
-        void set_is_paired(binary_sensor::BinarySensor *is_paired) { this->is_paired_ = is_paired; }
-        void set_battery_critical(binary_sensor::BinarySensor *battery_critical) { this->battery_critical_ = battery_critical; }
-        void set_battery_level(sensor::Sensor *battery_level) { this->battery_level_ = battery_level; }
-        void set_door_sensor(binary_sensor::BinarySensor *door_sensor) { this->door_sensor_ = door_sensor; }
-        void set_door_sensor_state(text_sensor::TextSensor *door_sensor_state) { this->door_sensor_state_ = door_sensor_state; }
-        void set_unpair_button(button::Button *unpair_button) { this->unpair_button_ = unpair_button; }
-        void set_pairing_mode_switch(switch_::Switch *pairing_mode_switch) { this->pairing_mode_switch_ = pairing_mode_switch; }
         void set_security_pin(uint16_t security_pin) { this->security_pin_ = security_pin; }
         void set_pairing_mode_timeout(uint16_t pairing_mode_timeout) { this->pairing_mode_timeout_ = pairing_mode_timeout; }
+        
         void add_pairing_mode_on_callback(std::function<void()> &&callback);
         void add_pairing_mode_off_callback(std::function<void()> &&callback);
         void add_paired_callback(std::function<void()> &&callback);
-
-        float get_setup_priority() const override { return setup_priority::HARDWARE - 1.0f; }
-
-        void dump_config() override;
-
-        lock::LockState nuki_to_lock_state(NukiLock::LockState);
-        bool nuki_doorsensor_to_binary(Nuki::DoorSensorState);
-        std::string nuki_doorsensor_to_string(Nuki::DoorSensorState nukiDoorSensorState);
-
-        void notify(Nuki::EventType eventType) override;
-
-        void unpair();
-
-        void set_pairing_mode(bool enabled);
 
         CallbackManager<void()> pairing_mode_on_callback_{};
         CallbackManager<void()> pairing_mode_off_callback_{};
         CallbackManager<void()> paired_callback_{};
 
+        lock::LockState nuki_to_lock_state(NukiLock::LockState);
+        bool nuki_doorsensor_to_binary(Nuki::DoorSensorState);
+        std::string nuki_doorsensor_to_string(Nuki::DoorSensorState nukiDoorSensorState);
+
+        void unpair();
+        void set_pairing_mode(bool enabled);
+        void set_button_enabled(bool enabled);
+        void set_led_enabled(bool enabled);
+        void set_led_brightness(float value);
+
     protected:
         void control(const lock::LockCall &call) override;
+        void open_latch() override { this->open_latch_ = true; unlock();}
+
         void update_status();
         void update_config();
         bool executeLockAction(NukiLock::LockAction lockAction);
-        void open_latch() override { this->open_latch_ = true; unlock();}
-
-        binary_sensor::BinarySensor *is_connected_{nullptr};
-        binary_sensor::BinarySensor *is_paired_{nullptr};
-        binary_sensor::BinarySensor *battery_critical_{nullptr};
-        binary_sensor::BinarySensor *door_sensor_{nullptr};
-        text_sensor::TextSensor *door_sensor_state_{nullptr};
-        sensor::Sensor *battery_level_{nullptr};
-        button::Button *unpair_button_{nullptr};
-        switch_::Switch *pairing_mode_switch_{nullptr};
 
         BleScanner::Scanner scanner_;
         NukiLock::KeyTurnerState retrievedKeyTurnerState_;
@@ -125,6 +151,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
         bool keypad_paired_;
 };
 
+// Actions
 template<typename... Ts> class NukiLockUnpairAction : public Action<Ts...> {
     public:
         NukiLockUnpairAction(NukiLockComponent *parent) : parent_(parent) {}
@@ -146,6 +173,7 @@ template<typename... Ts> class NukiLockPairingModeAction : public Action<Ts...> 
         NukiLockComponent *parent_;
 };
 
+// Callbacks
 class PairingModeOnTrigger : public Trigger<> {
     public:
         explicit PairingModeOnTrigger(NukiLockComponent *parent) {
@@ -167,27 +195,59 @@ class PairedTrigger : public Trigger<> {
         }
 };
 
-class NukiLockUnpairButton : public Component, public button::Button {
+// Entities
+class NukiLockUnpairButton : public button::Button, public Parented<NukiLockComponent> {
     public:
-        void set_parent(NukiLockComponent *parent) { this->parent_ = parent; }
+        NukiLockUnpairButton() = default;
     protected:
         void press_action() override;
-        void dump_config() override;
-        NukiLockComponent *parent_;
 };
 
-class NukiLockPairingModeSwitch : public Component, public switch_::Switch {
+class NukiLockPairingModeSwitch : public Component, public switch_::Switch, public Parented<NukiLockComponent> {
     public:
+        NukiLockPairingModeSwitch() = default;
         Trigger<> *get_turn_on_trigger() const;
         Trigger<> *get_turn_off_trigger() const;
-        void set_parent(NukiLockComponent *parent) { this->parent_ = parent; }
     protected:
         void setup() override;
-        void dump_config() override;
         void write_state(bool state) override;
         Trigger<> *turn_on_trigger_;
         Trigger<> *turn_off_trigger_;
-        NukiLockComponent *parent_;
+};
+
+class NukiLockButtonEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
+   public:
+      NukiLockButtonEnabledSwitch() = default;
+      Trigger<> *get_turn_on_trigger() const;
+      Trigger<> *get_turn_off_trigger() const;
+
+   protected:
+      void setup() override;
+      void write_state(bool state) override;
+      Trigger<> *turn_on_trigger_;
+      Trigger<> *turn_off_trigger_;
+};
+
+class NukiLockLedEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
+    public:
+        NukiLockLedEnabledSwitch() = default;
+        Trigger<> *get_turn_on_trigger() const;
+        Trigger<> *get_turn_off_trigger() const;
+
+    protected:
+        void setup() override;
+        void write_state(bool state) override;
+        Trigger<> *turn_on_trigger_;
+        Trigger<> *turn_off_trigger_;
+};
+
+class NukiLockLedBrightnessNumber : public number::Number, public Parented<NukiLockComponent> {
+    public:
+        NukiLockLedBrightnessNumber() = default;
+
+    protected:
+        void setup() override;
+        void control(float value) override;
 };
 
 } //namespace nuki_lock

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -208,13 +208,12 @@ class NukiLockUnpairButton : public button::Button, public Parented<NukiLockComp
 #endif
 
 #ifdef USE_SWITCH
-class NukiLockPairingModeSwitch : public Component, public switch_::Switch, public Parented<NukiLockComponent> {
+class NukiLockPairingModeSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
     public:
         NukiLockPairingModeSwitch() = default;
         Trigger<> *get_turn_on_trigger() const;
         Trigger<> *get_turn_off_trigger() const;
     protected:
-        void setup() override;
         void write_state(bool state) override;
         Trigger<> *turn_on_trigger_;
         Trigger<> *turn_off_trigger_;
@@ -227,7 +226,6 @@ class NukiLockAutoUnlatchEnabledSwitch : public switch_::Switch, public Parented
       Trigger<> *get_turn_off_trigger() const;
 
    protected:
-      void setup() override;
       void write_state(bool state) override;
       Trigger<> *turn_on_trigger_;
       Trigger<> *turn_off_trigger_;
@@ -240,7 +238,6 @@ class NukiLockButtonEnabledSwitch : public switch_::Switch, public Parented<Nuki
       Trigger<> *get_turn_off_trigger() const;
 
    protected:
-      void setup() override;
       void write_state(bool state) override;
       Trigger<> *turn_on_trigger_;
       Trigger<> *turn_off_trigger_;
@@ -253,7 +250,6 @@ class NukiLockLedEnabledSwitch : public switch_::Switch, public Parented<NukiLoc
         Trigger<> *get_turn_off_trigger() const;
 
     protected:
-        void setup() override;
         void write_state(bool state) override;
         Trigger<> *turn_on_trigger_;
         Trigger<> *turn_off_trigger_;
@@ -266,7 +262,6 @@ class NukiLockLedBrightnessNumber : public number::Number, public Parented<NukiL
         NukiLockLedBrightnessNumber() = default;
 
     protected:
-        void setup() override;
         void control(float value) override;
 };
 #endif

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -33,7 +33,7 @@
 namespace esphome {
 namespace nuki_lock {
 
-static const char *TAG = "nukilock.lock";
+static const char *TAG = "nuki_lock.lock";
 
 class NukiLockComponent : public lock::Lock, public PollingComponent, public api::CustomAPIDevice, public Nuki::SmartlockEventHandler {
     
@@ -58,6 +58,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
     #ifdef USE_SWITCH
     SUB_SWITCH(pairing_mode)
     SUB_SWITCH(button_enabled)
+    SUB_SWITCH(auto_unlatch_enabled)
     SUB_SWITCH(led_enabled)
     #endif
 
@@ -103,6 +104,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
 
         void unpair();
         void set_pairing_mode(bool enabled);
+        void set_auto_unlatch_enabled(bool enabled);
         void set_button_enabled(bool enabled);
         void set_led_enabled(bool enabled);
         void set_led_brightness(float value);
@@ -196,13 +198,16 @@ class PairedTrigger : public Trigger<> {
 };
 
 // Entities
+#ifdef USE_BUTTON
 class NukiLockUnpairButton : public button::Button, public Parented<NukiLockComponent> {
     public:
         NukiLockUnpairButton() = default;
     protected:
         void press_action() override;
 };
+#endif
 
+#ifdef USE_SWITCH
 class NukiLockPairingModeSwitch : public Component, public switch_::Switch, public Parented<NukiLockComponent> {
     public:
         NukiLockPairingModeSwitch() = default;
@@ -213,6 +218,19 @@ class NukiLockPairingModeSwitch : public Component, public switch_::Switch, publ
         void write_state(bool state) override;
         Trigger<> *turn_on_trigger_;
         Trigger<> *turn_off_trigger_;
+};
+
+class NukiLockAutoUnlatchEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
+   public:
+      NukiLockAutoUnlatchEnabledSwitch() = default;
+      Trigger<> *get_turn_on_trigger() const;
+      Trigger<> *get_turn_off_trigger() const;
+
+   protected:
+      void setup() override;
+      void write_state(bool state) override;
+      Trigger<> *turn_on_trigger_;
+      Trigger<> *turn_off_trigger_;
 };
 
 class NukiLockButtonEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
@@ -240,7 +258,9 @@ class NukiLockLedEnabledSwitch : public switch_::Switch, public Parented<NukiLoc
         Trigger<> *turn_on_trigger_;
         Trigger<> *turn_off_trigger_;
 };
+#endif
 
+#ifdef USE_NUMBER
 class NukiLockLedBrightnessNumber : public number::Number, public Parented<NukiLockComponent> {
     public:
         NukiLockLedBrightnessNumber() = default;
@@ -249,6 +269,7 @@ class NukiLockLedBrightnessNumber : public number::Number, public Parented<NukiL
         void setup() override;
         void control(float value) override;
 };
+#endif
 
 } //namespace nuki_lock
 } //namespace esphome

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -77,8 +77,13 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
 
     static const uint8_t BLE_CONNECT_TIMEOUT_SEC = 3;
     static const uint8_t BLE_CONNECT_TIMEOUT_RETRIES = 1;
+
     static const uint8_t MAX_ACTION_ATTEMPTS = 5;
     static const uint8_t MAX_TOLERATED_UPDATES_ERRORS = 5;
+
+    static const uint8_t MAX_AUTH_DATA_ENTRIES = 10;
+    static const uint8_t MAX_EVENT_LOG_ENTRIES = 3;
+
     static const uint32_t COOLDOWN_COMMANDS_MILLIS = 1000;
     static const uint32_t COOLDOWN_COMMANDS_EXTENDED_MILLIS = 3000;
 

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -102,7 +102,8 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
 
         void set_security_pin(uint16_t security_pin) { this->security_pin_ = security_pin; }
         void set_pairing_mode_timeout(uint16_t pairing_mode_timeout) { this->pairing_mode_timeout_ = pairing_mode_timeout; }
-        
+        void set_event(const char *event) { this->event_ = event; }
+
         void add_pairing_mode_on_callback(std::function<void()> &&callback);
         void add_pairing_mode_off_callback(std::function<void()> &&callback);
         void add_paired_callback(std::function<void()> &&callback);
@@ -174,6 +175,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
         bool lock_n_go_;
 
         uint16_t security_pin_ = 0;
+        const char* event_;
 
         uint16_t pairing_mode_timeout_ = 0;
         bool pairing_mode_ = false;

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -89,9 +89,9 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
         explicit NukiLockComponent() : Lock(), open_latch_(false),
                                     lock_n_go_(false),
                                     keypad_paired_(false),
-                                    nukiLock_(deviceName_, deviceId_) {
+                                    nuki_lock_(deviceName_, deviceId_) {
                 this->traits.set_supports_open(true);
-                this->nukiLock_.setEventHandler(this);
+                this->nuki_lock_.setEventHandler(this);
         }
 
         void setup() override;
@@ -149,22 +149,22 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
 
         void update_event_logs();
         void update_auth_data();
-        void processLogEntries(const std::list<NukiLock::LogEntry>& logEntries);
+        void process_log_entries(const std::list<NukiLock::LogEntry>& logEntries);
 
-        bool executeLockAction(NukiLock::LockAction lockAction);
+        bool execute_lock_action(NukiLock::LockAction lockAction);
 
         BleScanner::Scanner scanner_;
-        NukiLock::KeyTurnerState retrievedKeyTurnerState_;
-        NukiLock::LockAction lockAction_;
+        NukiLock::KeyTurnerState retrieved_key_turner_state_;
+        NukiLock::LockAction lock_action_;
 
         std::map<uint32_t, std::string> auth_entries_;
         uint32_t auth_id_ = 0;
         char auth_name_[33];
 
-        uint32_t lastCommandExecutedTime_ = 0;
+        uint32_t last_command_executed_time_ = 0;
         uint32_t command_cooldown_millis = 0;
-        uint8_t actionAttempts_ = 0;
-        uint32_t statusUpdateConsecutiveErrors_ = 0;
+        uint8_t action_attempts_ = 0;
+        uint32_t status_update_consecutive_errors_ = 0;
 
         bool status_update_;
         bool config_update_;
@@ -176,15 +176,15 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
 
         uint16_t security_pin_ = 0;
         const char* event_;
-
         uint16_t pairing_mode_timeout_ = 0;
+
         bool pairing_mode_ = false;
         uint32_t pairing_mode_timer_ = 0;
 
         uint32_t last_rolling_log_id = 0;
 
     private:
-        NukiLock::NukiLock nukiLock_;
+        NukiLock::NukiLock nuki_lock_;
 
         void lock_n_go();
         void print_keypad_entries();
@@ -195,7 +195,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
         bool valid_keypad_name(std::string name);
         bool valid_keypad_code(int code);
 
-        std::vector<uint16_t> keypadCodeIds_;
+        std::vector<uint16_t> keypad_code_ids_;
         bool keypad_paired_;
 };
 

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -144,11 +144,20 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
         void update_status();
         void update_config();
         void update_advanced_config();
+
+        void update_event_logs();
+        void update_auth_data();
+        void processLogEntries(const std::list<NukiLock::LogEntry>& logEntries);
+
         bool executeLockAction(NukiLock::LockAction lockAction);
 
         BleScanner::Scanner scanner_;
         NukiLock::KeyTurnerState retrievedKeyTurnerState_;
         NukiLock::LockAction lockAction_;
+
+        std::map<uint32_t, std::string> auth_entries_;
+        uint32_t auth_id_ = 0;
+        char auth_name_[33];
 
         uint32_t lastCommandExecutedTime_ = 0;
         uint32_t command_cooldown_millis = 0;
@@ -158,6 +167,8 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
         bool status_update_;
         bool config_update_;
         bool advanced_config_update_;
+        bool auth_data_update_;
+        bool event_log_update_;
         bool open_latch_;
         bool lock_n_go_;
 

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -105,7 +105,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
         void setup() override;
         void update() override;
         void dump_config() override;
-        void notify(Nuki::EventType eventType) override;
+        void notify(Nuki::EventType event_type) override;
         float get_setup_priority() const override { return setup_priority::HARDWARE - 1.0f; }
 
         void set_security_pin(uint16_t security_pin) { this->security_pin_ = security_pin; }
@@ -122,7 +122,7 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
 
         lock::LockState nuki_to_lock_state(NukiLock::LockState);
         bool nuki_doorsensor_to_binary(Nuki::DoorSensorState);
-        std::string nuki_doorsensor_to_string(Nuki::DoorSensorState nukiDoorSensorState);
+        std::string nuki_doorsensor_to_string(Nuki::DoorSensorState nuki_door_sensor_state);
 
         uint8_t fob_action_to_int(std::string str);
         std::string fob_action_to_string(uint8_t action);
@@ -153,9 +153,9 @@ class NukiLockComponent : public lock::Lock, public PollingComponent, public api
 
         void update_event_logs();
         void update_auth_data();
-        void process_log_entries(const std::list<NukiLock::LogEntry>& logEntries);
+        void process_log_entries(const std::list<NukiLock::LogEntry>& log_entries);
 
-        bool execute_lock_action(NukiLock::LockAction lockAction);
+        bool execute_lock_action(NukiLock::LockAction lock_action);
 
         BleScanner::Scanner scanner_;
         NukiLock::KeyTurnerState retrieved_key_turner_state_;


### PR DESCRIPTION
This PR adds several basic and advanced settings entites as well as event support.

**Switch:**  
- Button Enabled
- LED Enabled
- Night Mode
- Night Mode: Auto Lock
- Night Mode: Reject Auto Unlock
- Night Mode: Lock at Start Time
- Auto Lock
- Auto Unlock: Disable
- Auto Lock: Immediately
- Automatic Updates

**Text Sensor:**
- Last Unlock User

**Select:**  
- Single Button Press Action
- Double Button Press Action
- Fob Action 1
- Fob Action 2
- Fob Action 3

**Number:**  
- LED Brightness

**Events:**
Lock events are sent to Home Assistant with the esphome.nuki identifier by default.
```
event_type: esphome.nuki
data:
  device_id: 373c62d6788cf81d322763235513310e
  action: Unlatch
  authorizationId: "3902896895"
  authorizationName: Nuki ESPHome
  completionStatus: success
  index: "92"
  timeDay: "25"
  timeHour: "0"
  timeMinute: "46"
  timeMonth: "10"
  timeSecond: "11"
  timeYear: "2024"
  trigger: system
  type: LockAction
origin: LOCAL
time_fired: "2024-10-25T00:46:33.398284+00:00"
context:
  id: 01JB0J7AXPMS5DWHG188Y6XFCP
  parent_id: null
  user_id: null
```