### PR TITLE
Refactor Event Logs, Security Pin as property

### DIFF
--- a/.github/test-config.yaml
+++ b/.github/test-config.yaml
@@ -79,8 +79,6 @@ lock:
 
     led_brightness:
       name: "Nuki LED Brightness"
-    security_pin:
-      name: "Nuki Security Pin"
     timezone_offset:
       name: "Nuki Timezone: Offset"
 
@@ -101,6 +99,7 @@ lock:
 
     pairing_mode_timeout: 300s
     event: "nuki"
+    security_pin: 1234
 
     on_pairing_mode_on_action:
       - lambda: ESP_LOGI("nuki_lock", "Pairing mode turned on");

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,9 +11,9 @@
       runs-on: ubuntu-latest
       steps:
         - name: Checkout
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
 
         - name: Compile Firmware
-          uses: esphome/build-action@v4.0.1
+          uses: esphome/build-action@v5.0.0
           with:
             yaml-file: .github/test-config.yaml

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ lock:
   # Optional: Settings
     pairing_mode_timeout: 300s
     event: "nuki"
+    security_pin: 1234
   # Optional: Binary Sensors
     is_connected:
       name: "Nuki Connected"
@@ -59,8 +60,6 @@ lock:
     led_enabled:
       name: "Nuki LED Signal"
   # Optional: Number Inputs
-    security_pin:
-      name: "Nuki Security Pin"
     led_brightness:
       name: "Nuki LED Brightness"
     timezone_offset:
@@ -197,6 +196,14 @@ on_...:
   - nuki_lock.unpair:
 ```
 
+### Action: Security Pin
+To override the security pin without recompiling, use the following action:
+```yaml
+on_...:
+  - nuki_lock.set_security_pin:
+      security_pin: 1234
+```
+
 ### Callbacks
 To run specific actions when certain events occur, you can use the following callbacks:
 ```yaml
@@ -295,7 +302,6 @@ context:
 **Number Input:**  
 - LED Brightness
 - Timezone Offset
-- Security Pin
 
 **Button:**  
 - Unpair Device

--- a/README.md
+++ b/README.md
@@ -209,7 +209,11 @@ on_paired_action:
 ```
 
 ### Events
-By default, this component sends Nuki logs as events to Home Assistant, enabling you to use them in automations. 
+By default, this component sends Nuki logs as events to Home Assistant, enabling you to use them in automations.
+
+> [!IMPORTANT]
+> To receive events, **you must set your security PIN**.
+> Without it, it's not possible to access any event logs from your lock.
 
 - **To Disable Logs**: Set the `event` property in your YAML configuration to `none` if you don't want to receive log events.
   

--- a/README.md
+++ b/README.md
@@ -197,6 +197,11 @@ on_...:
 ```
 
 ### Action: Security Pin
+
+> [!IMPORTANT]  
+> Overriding the security PIN will save it to flash!  
+> To revert back to the PIN defined in your YAML configuration, you must set the override PIN to `0`.
+
 To override the security pin without recompiling, use the following action:
 ```yaml
 on_...:
@@ -226,8 +231,8 @@ By default, this component sends Nuki logs as events to Home Assistant, enabling
   
 - **To View Log Events**: Go to **Home Assistant Developer Tools** -> **Events**, and listen for `esphome.nuki` events to monitor log activity.
 
-These log events provide insights into lock operations and help fine-tune automations based on real-time lock data.
-
+These log events provide insights into lock operations and help fine-tune automations based on lock data.
+Keep in mind that the logs **are not displayed in real-time** and may take up to a minute to arrive.
 
 Example Event:
 ```yaml
@@ -256,6 +261,11 @@ context:
 ```
 
 ## Entities
+
+> [!IMPORTANT]  
+> Most settings entities **require the security PIN** to make changes.  
+> Without the PIN, modifying these settings is not possible.  
+> Additionally, the `Last Unlock User` feature will only function if events are enabled!  
 
 **Lock:**  
 - Lock

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -625,8 +625,10 @@ async def to_code(config):
     cg.add_library(
         None,
         None,
-        "https://github.com/I-Connect/NukiBleEsp32#93e7da927171c8973b7ef857c7fa644c174ed47d",
+        "https://github.com/I-Connect/NukiBleEsp32#edc9586",
     )
+
+    cg.add_define("NUKI_ALT_CONNECT")
 
 
 # Actions

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -620,7 +620,7 @@ async def to_code(config):
 
     # Libraries
     cg.add_library("Preferences", None)
-    cg.add_library("h2zero/NimBLE-Arduino", "1.4.0")
+    cg.add_library("h2zero/NimBLE-Arduino", "1.4.2")
     cg.add_library("Crc16", None)
     cg.add_library(
         None,

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -622,7 +622,7 @@ async def to_code(config):
     cg.add_library(
         None,
         None,
-        "https://github.com/I-Connect/NukiBleEsp32#edc9586",
+        "https://github.com/I-Connect/NukiBleEsp32#940d809",
     )
 
     cg.add_define("NUKI_ALT_CONNECT")

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -729,7 +729,7 @@ void NukiLockComponent::setup() {
     if (!this->pref_.load(&recovered)) {
         recovered = {0};
     }
-    
+
     if(recovered.security_pin != 0)
     {
         this->security_pin_ = recovered.security_pin;
@@ -1125,6 +1125,12 @@ void NukiLockComponent::dump_config() {
 }
 
 void NukiLockComponent::notify(Nuki::EventType event_type) {
+    
+    // Ignore bad pin error to prevent loop
+    if(event_type == Nuki::EventType::ERROR_BAD_PIN) {
+        return;
+    }
+
     this->status_update_ = true;
     this->config_update_ = true;
     this->advanced_config_update_ = true;

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -263,16 +263,18 @@ void NukiLockComponent::update_status()
 
     if (cmd_result == Nuki::CmdResult::Success) {
         this->status_update_consecutive_errors_ = 0;
-        NukiLock::LockState current_lock_state = this->retrieved_key_turner_state_.lockState;
 
+        NukiLock::LockState current_lock_state = this->retrieved_key_turner_state_.lockState;
         char current_lock_state_as_string[30];
         NukiLock::lockstateToString(current_lock_state, current_lock_state_as_string);
 
-        char last_lock_action[30];
-        NukiLock::lockactionToString(this->retrieved_key_turner_state_.lastLockAction, last_lock_action);
+        /*NukiLock::LockAction last_lock_action = this->retrieved_key_turner_state_.lastLockAction;
+        char last_lock_action_str[30];
+        NukiLock::lockactionToString(last_lock_action, last_lock_action_str);
 
-        char last_lock_action_trigger[30];
-        NukiLock::triggerToString(this->retrieved_key_turner_state_.lastLockActionTrigger, last_lock_action_trigger);
+        NukiLock::Trigger last_lock_action_trigger = this->retrieved_key_turner_state_.lastLockActionTrigger;
+        char last_lock_action_trigger_str[30];
+        NukiLock::triggerToString(last_lock_action_trigger_str, last_lock_action_trigger);*/
 
         ESP_LOGI(TAG, "Bat state: %#x, Bat crit: %d, Bat perc: %d lock state: %s (%d) %d:%d:%d",
             this->retrieved_key_turner_state_.criticalBatteryState,
@@ -302,10 +304,10 @@ void NukiLockComponent::update_status()
         #ifdef USE_TEXT_SENSOR
         if (this->door_sensor_state_text_sensor_ != nullptr)
             this->door_sensor_state_text_sensor_->publish_state(this->nuki_doorsensor_to_string(this->retrieved_key_turner_state_.doorSensorState));
-        if (this->last_lock_action_text_sensor_ != nullptr)
-            this->last_lock_action_text_sensor_->publish_state(last_lock_action);
+        /*if (this->last_lock_action_text_sensor_ != nullptr)
+            this->last_lock_action_text_sensor_->publish_state(last_lock_action_str);
         if (this->last_lock_action_trigger_text_sensor_ != nullptr)
-            this->last_lock_action_trigger_text_sensor_->publish_state(last_lock_action_trigger);
+            this->last_lock_action_trigger_text_sensor_->publish_state(last_lock_action_trigger_str);*/
         #endif
 
         if (
@@ -1101,8 +1103,8 @@ void NukiLockComponent::dump_config() {
     #ifdef USE_TEXT_SENSOR
     LOG_TEXT_SENSOR(TAG, "Door Sensor State", this->door_sensor_state_text_sensor_);
     LOG_TEXT_SENSOR(TAG, "Last Unlock User", this->last_unlock_user_text_sensor_);
-    LOG_TEXT_SENSOR(TAG, "Last Lock Action", this->last_lock_action_text_sensor_);
-    LOG_TEXT_SENSOR(TAG, "Last Lock Action Trigger", this->last_lock_action_trigger_text_sensor_);
+    /*LOG_TEXT_SENSOR(TAG, "Last Lock Action", this->last_lock_action_text_sensor_);
+    LOG_TEXT_SENSOR(TAG, "Last Lock Action Trigger", this->last_lock_action_trigger_text_sensor_);*/
     #endif
     #ifdef USE_SENSOR
     LOG_SENSOR(TAG, "Battery Level", this->battery_level_sensor_);

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -268,13 +268,13 @@ void NukiLockComponent::update_status()
         char current_lock_state_as_string[30];
         NukiLock::lockstateToString(current_lock_state, current_lock_state_as_string);
 
-        /*NukiLock::LockAction last_lock_action = this->retrieved_key_turner_state_.lastLockAction;
+        NukiLock::LockAction last_lock_action = this->retrieved_key_turner_state_.lastLockAction;
         char last_lock_action_str[30];
         NukiLock::lockactionToString(last_lock_action, last_lock_action_str);
 
         NukiLock::Trigger last_lock_action_trigger = this->retrieved_key_turner_state_.lastLockActionTrigger;
         char last_lock_action_trigger_str[30];
-        NukiLock::triggerToString(last_lock_action_trigger_str, last_lock_action_trigger);*/
+        NukiLock::triggerToString(last_lock_action_trigger, last_lock_action_trigger_str);
 
         ESP_LOGI(TAG, "Bat state: %#x, Bat crit: %d, Bat perc: %d lock state: %s (%d) %d:%d:%d",
             this->retrieved_key_turner_state_.criticalBatteryState,
@@ -304,10 +304,10 @@ void NukiLockComponent::update_status()
         #ifdef USE_TEXT_SENSOR
         if (this->door_sensor_state_text_sensor_ != nullptr)
             this->door_sensor_state_text_sensor_->publish_state(this->nuki_doorsensor_to_string(this->retrieved_key_turner_state_.doorSensorState));
-        /*if (this->last_lock_action_text_sensor_ != nullptr)
+        if (this->last_lock_action_text_sensor_ != nullptr)
             this->last_lock_action_text_sensor_->publish_state(last_lock_action_str);
         if (this->last_lock_action_trigger_text_sensor_ != nullptr)
-            this->last_lock_action_trigger_text_sensor_->publish_state(last_lock_action_trigger_str);*/
+            this->last_lock_action_trigger_text_sensor_->publish_state(last_lock_action_trigger_str);
         #endif
 
         if (
@@ -435,104 +435,99 @@ void NukiLockComponent::update_advanced_config() {
     }
 }
 
-void NukiLockComponent::update_auth_data()
-{
+void NukiLockComponent::update_auth_data() {
     this->auth_data_update_ = false;
+    this->cancel_timeout("wait_for_auth_data");
 
-    Nuki::CmdResult conf_req_result = (Nuki::CmdResult)-1;
-    int retryCount = 0;
-    while(retryCount < 3)
-    {
-        ESP_LOGD(TAG, "Retrieve Auth Data");
-        conf_req_result = this->nuki_lock_.retrieveAuthorizationEntries(0, MAX_AUTH_DATA_ENTRIES);
+    ESP_LOGD(TAG, "Retrieve Auth Data");
 
-        if(conf_req_result != Nuki::CmdResult::Success)
-        {
-            ++retryCount;
-            App.feed_wdt();
-        }
-        else
-        {
-            break;
-        }
-    }
+    Nuki::CmdResult auth_data_req_result = this->nuki_lock_.retrieveAuthorizationEntries(0, MAX_AUTH_DATA_ENTRIES);
+    char auth_data_req_result_as_string[30];
+    NukiLock::cmdResultToString(auth_data_req_result, auth_data_req_result_as_string);
 
-    this->set_timeout("wait_for_auth_data", 5000, [this]() {
-        std::list<NukiLock::AuthorizationEntry> authEntries;
-        this->nuki_lock_.getAuthorizationEntries(&authEntries);
+    if (auth_data_req_result == Nuki::CmdResult::Success) {
+        ESP_LOGD(TAG, "retrieveAuthorizationEntries has resulted in %s (%d)", auth_data_req_result_as_string, auth_data_req_result);
+    
+        this->set_timeout("wait_for_auth_data", 5000, [this]() {
 
-        authEntries.sort([](const NukiLock::AuthorizationEntry& a, const NukiLock::AuthorizationEntry& b)
-        {
-            return a.authId < b.authId;
+            std::list<NukiLock::AuthorizationEntry> authEntries;
+            this->nuki_lock_.getAuthorizationEntries(&authEntries);
+    
+            ESP_LOGD(TAG, "Authorization Entries: %d", authEntries.size());
+
+            if(authEntries.size() > 0) {
+                authEntries.sort([](const NukiLock::AuthorizationEntry& a, const NukiLock::AuthorizationEntry& b) {
+                    return a.authId < b.authId;
+                });
+        
+                if(authEntries.size() > MAX_AUTH_DATA_ENTRIES) {
+                    authEntries.resize(MAX_AUTH_DATA_ENTRIES);
+                }
+        
+                for(const auto& entry : authEntries) {
+                    ESP_LOGD(TAG, "Authorization entry[%d] type: %d name: %s", entry.authId, entry.idType, entry.name);
+                    this->auth_entries_[entry.authId] = std::string(reinterpret_cast<const char*>(entry.name));
+                }
+        
+                // Request Event logs when Auth Data is available
+                this->event_log_update_ = true;
+            } else {
+                ESP_LOGD(TAG, "No auth entries! Did you set the security pin?");
+            }
         });
-
-        if(authEntries.size() > MAX_AUTH_DATA_ENTRIES)
-        {
-            authEntries.resize(MAX_AUTH_DATA_ENTRIES);
-        }
-
-        for(const auto& entry : authEntries)
-        {
-            ESP_LOGD(TAG, "Authorization entry[%d] type: %d name: %s", entry.authId, entry.idType, entry.name);
-            this->auth_entries_[entry.authId] = std::string(reinterpret_cast<const char*>(entry.name));
-        }
-
-        // Request Event logs when Auth Data is available
-        this->event_log_update_ = true;
-    });
+    } else {
+        ESP_LOGE(TAG, "retrieveAuthorizationEntries has resulted in %s (%d)", auth_data_req_result_as_string, auth_data_req_result);
+        this->auth_data_update_ = true;
+    }
 }
 
-void NukiLockComponent::update_event_logs()
-{
+void NukiLockComponent::update_event_logs() {
     this->event_log_update_ = false;
+    this->cancel_timeout("wait_for_log_entries");
 
-    Nuki::CmdResult conf_req_result = (Nuki::CmdResult)-1;
-    int retryCount = 0;
-    while(retryCount < 3)
-    {
-        ESP_LOGD(TAG, "Retrieve Event Logs");
-        conf_req_result = this->nuki_lock_.retrieveLogEntries(0, MAX_EVENT_LOG_ENTRIES, 1, false);
+    ESP_LOGD(TAG, "Retrieve Event Log Entries");
 
-        if(conf_req_result != Nuki::CmdResult::Success)
-        {
-            ++retryCount;
-            App.feed_wdt();
-        }
-        else
-        {
-            break;
-        }
-    }
+    Nuki::CmdResult event_log_req_result = this->nuki_lock_.retrieveLogEntries(0, MAX_EVENT_LOG_ENTRIES, 1, false);
+    char event_log_req_result_as_string[30];
+    NukiLock::cmdResultToString(event_log_req_result, event_log_req_result_as_string);
 
-    this->set_timeout("wait_for_log_entries", 5000, [this]() {
-        std::list<NukiLock::LogEntry> log;
-        this->nuki_lock_.getLogEntries(&log);
+    if (event_log_req_result == Nuki::CmdResult::Success) {
+        ESP_LOGD(TAG, "retrieveLogEntries has resulted in %s (%d)", event_log_req_result_as_string, event_log_req_result);
+        
+        this->set_timeout("wait_for_log_entries", 5000, [this]() {
+            std::list<NukiLock::LogEntry> log;
+            this->nuki_lock_.getLogEntries(&log);
+    
+            ESP_LOGD(TAG, "Log Entries: %d", log.size());
 
-        if(log.size() > MAX_EVENT_LOG_ENTRIES)
-        {
-            log.resize(MAX_EVENT_LOG_ENTRIES);
-        }
+            if(log.size() > 0) {
+                if(log.size() > MAX_EVENT_LOG_ENTRIES) {
+                    log.resize(MAX_EVENT_LOG_ENTRIES);
+                }
+        
+                log.sort([](const NukiLock::LogEntry& a, const NukiLock::LogEntry& b) {
+                    return a.index < b.index;
+                });
 
-        log.sort([](const NukiLock::LogEntry& a, const NukiLock::LogEntry& b)
-        {
-            return a.index < b.index;
+                this->process_log_entries(log);
+            } else {
+                ESP_LOGD(TAG, "No log entries! Did you set the security pin?");
+            }
         });
-
-        if(log.size() > 0)
-        {
-            this->process_log_entries(log);
-        }
-    });
+    } else {
+        ESP_LOGE(TAG, "retrieveAuthorizationEntries has resulted in %s (%d)", event_log_req_result_as_string, event_log_req_result);
+        this->event_log_update_ = true;
+    }
 }
 
-void NukiLockComponent::process_log_entries(const std::list<NukiLock::LogEntry>& log_entries)
-{
+void NukiLockComponent::process_log_entries(const std::list<NukiLock::LogEntry>& log_entries) {
+    ESP_LOGD(TAG, "Process Event Log Entries");
+
     char str[50];
     char auth_name[33];
     uint32_t auth_index = 0;
 
-    for(const auto& log : log_entries)
-    {
+    for(const auto& log : log_entries) {
         memset(auth_name, 0, sizeof(auth_name));
         auth_name[0] = '\0';
 
@@ -540,42 +535,38 @@ void NukiLockComponent::process_log_entries(const std::list<NukiLock::LogEntry>&
         {
             int sizeName = sizeof(log.name);
             memcpy(auth_name, log.name, sizeName);
-            if(auth_name[sizeName - 1] != '\0')
-            {
+            if(auth_name[sizeName - 1] != '\0') {
                 auth_name[sizeName] = '\0';
             }
 
-            if (std::string(auth_name) == "")
-            {
+            if (std::string(auth_name) == "") {
                 memset(auth_name, 0, sizeof(auth_name));
                 memcpy(auth_name, "Manual", strlen("Manual"));
             }
 
-            if(log.index > auth_index)
-            {
+            if(log.index > auth_index) {
                 auth_index = log.index;
                 this->auth_id_ = log.authId;
 
                 memset(this->auth_name_, 0, sizeof(this->auth_name_));
                 memcpy(this->auth_name_, auth_name, sizeof(auth_name));
 
-                if(auth_name[sizeName - 1] != '\0' && this->auth_entries_.count(this->auth_id_) > 0)
-                {
+                if(auth_name[sizeName - 1] != '\0' && this->auth_entries_.count(this->auth_id_) > 0) {
                     memset(this->auth_name_, 0, sizeof(this->auth_name_));
                     memcpy(this->auth_name_, this->auth_entries_[this->auth_id_].c_str(), sizeof(this->auth_entries_[this->auth_id_].c_str()));
                 }
             }
         }
 
-        if (strcmp(event_, "esphome.none") != 0)
-        {
+        if (strcmp(event_, "esphome.none") != 0) {
+            ESP_LOGD(TAG, "Prepare event data for %s", event_);
+
             std::map<std::string, std::string> event_data;
             event_data["index"] = std::to_string(log.index);
             event_data["authorizationId"] = std::to_string(log.authId);
             event_data["authorizationName"] = this->auth_name_;
 
-            if(this->auth_entries_.count(log.authId) > 0)
-            {
+            if(this->auth_entries_.count(log.authId) > 0) {
                 event_data["authorizationName"] = this->auth_entries_[log.authId];
             }
 
@@ -590,8 +581,7 @@ void NukiLockComponent::process_log_entries(const std::list<NukiLock::LogEntry>&
             NukiLock::loggingTypeToString(log.loggingType, str);
             event_data["type"] = str;
 
-            switch(log.loggingType)
-            {
+            switch(log.loggingType) {
                 case NukiLock::LoggingType::LockAction:
                     memset(str, 0, sizeof(str));
                     NukiLock::lockactionToString((NukiLock::LockAction)log.data[0], str);
@@ -611,8 +601,7 @@ void NukiLockComponent::process_log_entries(const std::list<NukiLock::LogEntry>&
                     NukiLock::lockactionToString((NukiLock::LockAction)log.data[0], str);
                     event_data["action"] = str;
 
-                    switch(log.data[1])
-                    {
+                    switch(log.data[1]) {
                         case 0:
                             event_data["trigger"] = "arrowkey";
                             break;
@@ -629,16 +618,11 @@ void NukiLockComponent::process_log_entries(const std::list<NukiLock::LogEntry>&
 
                     memset(str, 0, sizeof(str));
 
-                    if(log.data[2] == 9)
-                    {
+                    if(log.data[2] == 9) {
                         event_data["trigger"] = "notAuthorized";
-                    }
-                    else if (log.data[2] == 224)
-                    {
+                    } else if (log.data[2] == 224) {
                         event_data["trigger"] = "invalidCode";
-                    }
-                    else
-                    {
+                    } else {
                         NukiLock::completionStatusToString((NukiLock::CompletionStatus)log.data[2], str);
                         event_data["completionStatus"] = str;
                     }
@@ -647,8 +631,7 @@ void NukiLockComponent::process_log_entries(const std::list<NukiLock::LogEntry>&
                     break;
 
                 case NukiLock::LoggingType::DoorSensor:
-                    switch(log.data[0])
-                    {
+                    switch(log.data[0]) {
                         case 0:
                             event_data["action"] = "DoorOpened";
                             break;
@@ -667,8 +650,7 @@ void NukiLockComponent::process_log_entries(const std::list<NukiLock::LogEntry>&
             
             // Send as Home Assistant Event
             #ifdef USE_API
-            if(log.index > this->last_rolling_log_id)
-            {
+            if(log.index > this->last_rolling_log_id) {
                 this->last_rolling_log_id = log.index;
                 
                 auto capi = new esphome::api::CustomAPIDevice();
@@ -718,8 +700,7 @@ bool NukiLockComponent::execute_lock_action(NukiLock::LockAction lock_action) {
     }
 }
 
-void NukiLockComponent::set_security_pin(uint16_t security_pin)
-{
+void NukiLockComponent::set_security_pin(uint16_t security_pin) {
     this->security_pin_ = security_pin;
 
     bool result = this->nuki_lock_.saveSecurityPincode(this->security_pin_);
@@ -746,8 +727,7 @@ void NukiLockComponent::setup() {
     this->pref_ = global_preferences->make_preference<NukiLockSettings>(global_nuki_lock_id);
 
     NukiLockSettings recovered;
-    if (!this->pref_.load(&recovered))
-    {
+    if (!this->pref_.load(&recovered)) {
         recovered = {0};
     }
     this->set_security_pin(recovered.security_pin);
@@ -1103,8 +1083,8 @@ void NukiLockComponent::dump_config() {
     #ifdef USE_TEXT_SENSOR
     LOG_TEXT_SENSOR(TAG, "Door Sensor State", this->door_sensor_state_text_sensor_);
     LOG_TEXT_SENSOR(TAG, "Last Unlock User", this->last_unlock_user_text_sensor_);
-    /*LOG_TEXT_SENSOR(TAG, "Last Lock Action", this->last_lock_action_text_sensor_);
-    LOG_TEXT_SENSOR(TAG, "Last Lock Action Trigger", this->last_lock_action_trigger_text_sensor_);*/
+    LOG_TEXT_SENSOR(TAG, "Last Lock Action", this->last_lock_action_text_sensor_);
+    LOG_TEXT_SENSOR(TAG, "Last Lock Action Trigger", this->last_lock_action_trigger_text_sensor_);
     #endif
     #ifdef USE_SENSOR
     LOG_SENSOR(TAG, "Battery Level", this->battery_level_sensor_);


### PR DESCRIPTION
This includes:
- Refactored event log/auth data retry logic
- Add hint for the need of the security pin
- Use the latest NukiBleEsp32 commit
- Use the new alternative connect mode
- Add a new action to override the security pin and save it to flash (this allows to have a number entity which can still set the pin by fire and forget)
- Request auth data and event logs only when events are enabled

Breaking Changes:
- Move the security pin to a yaml property and remove the number entity