### PR TITLE
Compatibility for ESPHome 2025.10.0

### DIFF
--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -1125,16 +1125,14 @@ void NukiLockComponent::setup() {
 
     this->pin_state_ = recovered.pin_state;
 
-    this->traits.set_supported_states(
-        std::set<lock::LockState> {
-            lock::LOCK_STATE_NONE,
-            lock::LOCK_STATE_LOCKED,
-            lock::LOCK_STATE_UNLOCKED,
-            lock::LOCK_STATE_JAMMED,
-            lock::LOCK_STATE_LOCKING,
-            lock::LOCK_STATE_UNLOCKING
-        }
-    );
+    this->traits.set_supported_states({
+        lock::LOCK_STATE_NONE,
+        lock::LOCK_STATE_LOCKED,
+        lock::LOCK_STATE_UNLOCKED,
+        lock::LOCK_STATE_JAMMED,
+        lock::LOCK_STATE_LOCKING,
+        lock::LOCK_STATE_UNLOCKING
+    });
 
     this->scanner_.initialize("ESPHomeNuki", true, 40, 40);
     this->scanner_.setScanDuration(0);


### PR DESCRIPTION
This adds compatibility for the upcoming ESPHome version as it has a breaking change regarding locks.
It will continue to work with older versions.