### PR TITLE
Add more Lock Settings

### DIFF
--- a/.github/shared.yaml
+++ b/.github/shared.yaml
@@ -33,6 +33,20 @@ lock:
   - platform: nuki_lock
     name: Nuki Lock
 
+    pairing_mode_timeout: 300s
+    event: "nuki"
+    security_pin: 1234
+    pairing_as_app: false
+    query_interval_config: 3600s
+    query_interval_auth_data: 7200s
+    ble_general_timeout: 3s
+    ble_command_timeout: 3s
+
+    unpair:
+      name: "Unpair Device"
+    pairing_mode:
+      name: "Pairing Mode"
+
     connected:
       name: "Nuki Connected"
     paired:
@@ -45,7 +59,7 @@ lock:
     battery_level:
       name: "Nuki Battery Level"
     bt_signal_strength:
-      name: "Bluetooth Signal Strength"
+      name: "Nuki Bluetooth Signal Strength"
     
     door_sensor_state:
       name: "Nuki Door Sensor: State"
@@ -58,11 +72,11 @@ lock:
     pin_status:
       name: "Nuki Security Pin Status"
 
-    unpair:
-      name: "Nuki Unpair Device"
+    request_calibration:
+      name: "Nuki Request Calibration"
       
-    pairing_mode:
-      name: "Nuki Pairing Mode"
+    pairing_enabled:
+      name: "Nuki Pairing Enabled"
     auto_unlatch:
       name: "Nuki Auto unlatch"
     button_enabled:
@@ -98,6 +112,10 @@ lock:
       name: "Nuki Timezone: Offset"
     lock_n_go_timeout:
       name: "Nuki LockNGo Timeout"
+    auto_lock_timeout:
+      name: "Nuki Auto Lock Timeout"
+    unlatch_duration:
+      name: "Nuki Unlatch Duration"
 
     single_buton_press_action:
       name: "Nuki Single Button Press Action"
@@ -116,16 +134,6 @@ lock:
     battery_type:
       name: "Nuki Battery Type"
 
-    pairing_mode_timeout: 300s
-    event: "nuki"
-    security_pin: 1234
-    pairing_as_app: false
-    query_interval_config: 3600s
-    query_interval_auth_data: 7200s
-    ble_general_timeout: 3s
-    ble_command_timeout: 3s
-
-
     on_pairing_mode_on_action:
       - lambda: ESP_LOGI("nuki_lock", "Pairing mode turned on");
     on_pairing_mode_off_action:
@@ -141,6 +149,11 @@ button:
     name: Unpair
     on_press:
       - nuki_lock.unpair:
+
+  - platform: template
+    name: Request Calibration
+    on_press:
+      - nuki_lock.request_calibration:
 
   - platform: template
     name: Enable pairing-mode

--- a/.github/shared.yaml
+++ b/.github/shared.yaml
@@ -76,13 +76,13 @@ lock:
       name: "Nuki Request Calibration"
       
     pairing_enabled:
-      name: "Nuki Pairing Enabled"
+      name: "Nuki Button: Bluetooth Pairing"
     auto_unlatch:
       name: "Nuki Auto unlatch"
     button_enabled:
       name: "Nuki Button: Locking operations"
     led_enabled:
-      name: "Nuki LED Signal"
+      name: "Nuki LED: Signal"
     night_mode_enabled:
       name: "Nuki Night Mode"
     night_mode_auto_lock_enabled:
@@ -109,7 +109,7 @@ lock:
       name: "Nuki Detached Cylinder"
 
     led_brightness:
-      name: "Nuki LED Brightness"
+      name: "Nuki LED: Brightness"
     timezone_offset:
       name: "Nuki Timezone: Offset"
     lock_n_go_timeout:

--- a/.github/shared.yaml
+++ b/.github/shared.yaml
@@ -35,8 +35,8 @@ lock:
 
     pairing_mode_timeout: 300s
     event: "nuki"
-    security_pin: 1234
-    pairing_as_app: false
+    security_pin: 1234 # templatable
+    pairing_as_app: false # templatable
     query_interval_config: 3600s
     query_interval_auth_data: 7200s
     ble_general_timeout: 3s

--- a/.github/shared.yaml
+++ b/.github/shared.yaml
@@ -105,17 +105,27 @@ lock:
       name: "Nuki Daylight Saving Time"
     auto_battery_type_detection_enabled:
       name: "Nuki Automatic Battery Type Detection"
+    detached_cylinder_enabled:
+      name: "Nuki Detached Cylinder"
 
     led_brightness:
       name: "Nuki LED Brightness"
     timezone_offset:
       name: "Nuki Timezone: Offset"
     lock_n_go_timeout:
-      name: "Nuki LockNGo Timeout"
+      name: "Nuki Lock 'n' Go Timeout"
     auto_lock_timeout:
       name: "Nuki Auto Lock Timeout"
     unlatch_duration:
       name: "Nuki Unlatch Duration"
+    unlocked_position_offset:
+      name: "Nuki Unlocked Position Offset Degrees"
+    locked_position_offset:
+      name: "Nuki Locked Position Offset Degrees"
+    single_locked_position_offset:
+      name: "Nuki Single Locked Position Offset Degrees"
+    unlocked_to_locked_transition_offset:
+      name: "Nuki Unlocked to Locked Transition Offset Degrees"
 
     single_buton_press_action:
       name: "Nuki Single Button Press Action"

--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ Then continue with the pairing instructions below.
 
 2. Before activating pairing mode on the lock, configure ESPHome with:
 
-   * `pairing_as_app: true`
    * `security_pin: 123456`: your 6-digit PIN for the Ultra/Go/5th Gen lock
 
 > [!IMPORTANT]
@@ -262,7 +261,7 @@ The following configuration options allow you to customize the behavior of the N
 | `security_pin`             | Required for event logs & advanced operations (mandatory for Ultra/Go/5th Gen pairing - remove leading zeros: 000548 → 548) | —       |
 | `pairing_mode_timeout`     | Auto-timeout for pairing mode                 | `300s`  |
 | `event`                    | Event log event name (`none` disables logs)   | `none`  |
-| `pairing_as_app`           | Pair as app (required for Ultra/Go/5th Gen)   | `false` |
+| `pairing_as_app`           | Pair as app                                   | `false` |
 | `query_interval_config`    | Config refresh interval                       | `3600s` |
 | `query_interval_auth_data` | Auth data refresh interval                    | `7200s` |
 | `ble_general_timeout`      | General BLE timeout                           | `3s`    |

--- a/README.md
+++ b/README.md
@@ -122,11 +122,20 @@ lock:
     timezone_offset:
       name: "Nuki Timezone: Offset"
     lock_n_go_timeout:
-      name: "Nuki LockNGo Timeout"
+      name: "Nuki Lock 'n' Go Timeout"
     auto_lock_timeout:
       name: "Nuki Auto Lock Timeout"
     unlatch_duration:
       name: "Nuki Unlatch Duration"
+    # Advanced Calibration
+    unlocked_position_offset:
+      name: "Nuki Unlocked Position Offset Degrees"
+    locked_position_offset:
+      name: "Nuki Locked Position Offset Degrees"
+    single_locked_position_offset:
+      name: "Nuki Single Locked Position Offset Degrees"
+    unlocked_to_locked_transition_offset:
+      name: "Nuki Unlocked to Locked Transition Offset Degrees"
 
   # Optional: Switches
     pairing_enabled:
@@ -161,6 +170,8 @@ lock:
       name: "Nuki Automatic Battery Type Detection"
     slow_speed_during_night_mode_enabled:
       name: "Nuki Slow Speed During Night Mode"
+    detached_cylinder_enabled:
+      name: "Nuki Detached Cylinder"
 
   # Optional: Select Inputs
     single_buton_press_action:
@@ -508,6 +519,7 @@ context:
 - Automatic Updates
 - Automatic Battery Type Detection (Smart Lock Gen 1-4)
 - Slow Speed During Night Mode (Smart Lock Ultra)
+- Detached Cylinder
 
 **Button:**  
 - Request Calibration
@@ -526,9 +538,13 @@ context:
 **Number Input:**  
 - LED Brightness
 - Timezone Offset
-- LockNGo Timeout
+- Lock 'n' Go Timeout
 - Auto Lock Timeout
 - Unlatch Duration
+- Unlocked Position Offset Degrees
+- Locked Position Offset Degrees
+- Single Locked Position Offset Degrees
+- Unlocked to Locked Transition Offset Degrees
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ lock:
     battery_level:
       name: "Nuki Battery Level"
     bt_signal_strength:
-      name: "Bluetooth Signal Strength"
+      name: "Nuki Bluetooth Signal Strength"
 
   # Optional: Text Sensors
     door_sensor_state:
@@ -123,8 +123,14 @@ lock:
       name: "Nuki Timezone: Offset"
     lock_n_go_timeout:
       name: "Nuki LockNGo Timeout"
+    auto_lock_timeout:
+      name: "Nuki Auto Lock Timeout"
+    unlatch_duration:
+      name: "Nuki Unlatch Duration"
 
   # Optional: Switches
+    pairing_enabled:
+      name: "Nuki Pairing Enabled"
     auto_unlatch:
       name: "Nuki Auto unlatch"
     button_enabled:
@@ -338,6 +344,13 @@ on_...:
   - nuki_lock.unpair:
 ```
 
+## Action: Request Calibration
+To request a calibration of your Nuki Smart Lock, use the following action:
+```yaml
+on_...:
+  - nuki_lock.request_calibration:
+```
+
 ## Action: Security Pin
 
 > [!CAUTION]  
@@ -480,6 +493,7 @@ context:
 - Last Lock Action Trigger
 
 **Switch:**  
+- Pairing Enabled
 - Button Enabled
 - LED Enabled
 - Night Mode
@@ -495,6 +509,9 @@ context:
 - Automatic Battery Type Detection (Smart Lock Gen 1-4)
 - Slow Speed During Night Mode (Smart Lock Ultra)
 
+**Button:**  
+- Request Calibration
+
 **Select Input:**  
 - Single Button Press Action
 - Double Button Press Action
@@ -509,6 +526,9 @@ context:
 **Number Input:**  
 - LED Brightness
 - Timezone Offset
+- LockNGo Timeout
+- Auto Lock Timeout
+- Unlatch Duration
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESPHome Nuki Lock Component (ESP32) [![Build Component](https://github.com/uriyacovy/ESPHome_nuki_lock/actions/workflows/build.yaml/badge.svg)](https://github.com/uriyacovy/ESPHome_nuki_lock/actions/workflows/build.yaml)
 
-Seamlessly integrate Nuki Smart Locks (1st–5th Gen, Ultra, Go) with ESPHome, enabling a full-featured Home Assistant lock platform with [many available entities](#-entities).
+Seamlessly integrate Nuki Smart Locks (1st–5th Gen, Ultra, Go, Pro) with ESPHome, enabling a full-featured Home Assistant lock platform with [many available entities](#-entities).
 The lock state is always up-to-date thanks to Nuki's BLE advertisement mechanism—whether controlled through the Nuki app, Home Assistant, or physically at the door.
 
 ![some dashboard entites](./docs/nuki_dashboard.png)
@@ -64,7 +64,7 @@ lock:
     event: "none"
     
   # Needed to change most of the lock settings
-  # Needed to pair with Smart Lock Ultra/5th Gen/Go (6 digit pin)
+  # Needed to pair with Smart Lock Ultra/5th Gen/Go/Pro (6 digit pin)
   # Supports templating
     security_pin: 1234
 
@@ -217,7 +217,7 @@ Then continue with the pairing instructions below.
 
 # 🔐 Pairing Your Nuki Lock
 
-## Pairing with Nuki Lock (1st–4th Gen)
+## Pairing with Nuki Smart Lock (1st – 4th Gen)
 
 1. In the official Nuki App, make sure **Bluetooth pairing** is enabled:  
    **Settings → Features & Configuration → Button and LED**.  
@@ -231,14 +231,14 @@ Then continue with the pairing instructions below.
 > [!NOTE]  
 > The ESPHome bridge *can* run alongside an official Nuki Bridge, but this is not recommended (except in hybrid mode). Running both may increase battery drain and cause missed updates. If you need both, set `pairing_as_app: true` **before pairing**. Otherwise, pairing with the ESPHome bridge will unregister the official Bridge.
 
-## Pairing with Nuki Lock Ultra / Nuki Lock Go / Nuki Lock 5th Gen Pro
+## Pairing with Nuki Smart Lock Ultra / 5th Gen / Go / Pro
 
 1. In the official Nuki App, ensure **Bluetooth pairing** is enabled:  
    **Settings → Features & Configuration → Button and LED**.
 
 2. Before activating pairing mode on the lock, configure ESPHome with:
 
-   * `security_pin: 123456`: your 6-digit PIN for the Ultra/Go/5th Gen lock
+   * `security_pin: 123456`: your 6-digit PIN for the Nuki Smart Lock Ultra/5th Gen/Go/Pro
 
 > [!IMPORTANT]
 > If your PIN starts with zeros, remove them (e.g., 000548 → 548). Pairing will fail if you include leading zeros.
@@ -258,7 +258,7 @@ The following configuration options allow you to customize the behavior of the N
 
 | Option                     | Description                                   | Default |
 | -------------------------- | --------------------------------------------- | ------- |
-| `security_pin`             | Required for event logs & advanced operations (mandatory for Ultra/Go/5th Gen pairing - remove leading zeros: 000548 → 548) | —       |
+| `security_pin`             | Required for event logs & advanced operations (mandatory for Ultra/5th Gen/Go/Pro pairing - remove leading zeros: 000548 → 548) | —       |
 | `pairing_mode_timeout`     | Auto-timeout for pairing mode                 | `300s`  |
 | `event`                    | Event log event name (`none` disables logs)   | `none`  |
 | `pairing_as_app`           | Pair as app                                   | `false` |

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ lock:
 
   # Optional: Number Inputs
     led_brightness:
-      name: "Nuki LED Brightness"
+      name: "Nuki LED: Brightness"
     timezone_offset:
       name: "Nuki Timezone: Offset"
     lock_n_go_timeout:
@@ -139,13 +139,13 @@ lock:
 
   # Optional: Switches
     pairing_enabled:
-      name: "Nuki Pairing Enabled"
+      name: "Nuki Button: Bluetooth Pairing"
     auto_unlatch:
       name: "Nuki Auto unlatch"
     button_enabled:
       name: "Nuki Button: Locking operations"
     led_enabled:
-      name: "Nuki LED Signal"
+      name: "Nuki LED: Signal"
     night_mode_enabled:
       name: "Nuki Night Mode"
     night_mode_auto_lock_enabled:
@@ -504,9 +504,9 @@ context:
 - Last Lock Action Trigger
 
 **Switch:**  
-- Pairing Enabled
-- Button Enabled
-- LED Enabled
+- Button: Bluetooth Pairing
+- Button: Locking operations
+- LED Signal
 - Night Mode
 - Night Mode: Auto Lock
 - Night Mode: Reject Auto Unlock
@@ -536,7 +536,7 @@ context:
 - Motor Speed (Smart Lock Ultra)
 
 **Number Input:**  
-- LED Brightness
+- LED: Brightness
 - Timezone Offset
 - Lock 'n' Go Timeout
 - Auto Lock Timeout

--- a/components/nuki_lock/automation.h
+++ b/components/nuki_lock/automation.h
@@ -15,6 +15,12 @@ class NukiLockUnpairAction : public Action<Ts...>, public Parented<NukiLockCompo
 };
 
 template<typename... Ts>
+class NukiLockRequestCalibrationAction : public Action<Ts...>, public Parented<NukiLockComponent> {
+    public:
+        void play(const Ts&... x) override { this->parent_->request_calibration(); }
+};
+
+template<typename... Ts>
 class NukiLockPairingModeAction : public Action<Ts...>, public Parented<NukiLockComponent> {
     TEMPLATABLE_VALUE(bool, pairing_mode)
 

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -15,7 +15,6 @@ from esphome.const import (
     DEVICE_CLASS_DOOR,
     DEVICE_CLASS_SWITCH,
     DEVICE_CLASS_BUTTON,
-    DEVICE_CLASS_LIGHT,
     DEVICE_CLASS_SIGNAL_STRENGTH,
     UNIT_SECOND,
     UNIT_MINUTE,
@@ -362,7 +361,7 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_LED_ENABLED_SWITCH): switch.switch_schema(
                 NukiLockLedEnabledSwitch,
-                device_class=DEVICE_CLASS_LIGHT,
+                device_class=DEVICE_CLASS_SWITCH,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:led-on"
             ),

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -908,6 +908,24 @@ async def to_code(config):
 
     # Libraries
     add_idf_component(
+        name="espressif/libsodium",
+        ref="^1.0.20~2",
+    )
+    add_idf_component(
+        name="crc16",
+        repo="https://github.com/AzonInc/Crc16.git",
+    )
+    add_idf_component(
+        name="ble-scanner",
+        repo="https://github.com/AzonInc/ble-scanner.git",
+        ref="2.1.0",
+    )
+    add_idf_component(
+        name="esp-nimble-cpp",
+        repo="https://github.com/h2zero/esp-nimble-cpp.git",
+        ref="2.3.3",
+    )
+    add_idf_component(
         name="NukiBleEsp32",
         repo="https://github.com/AzonInc/NukiBleEsp32.git",
         ref="idf",

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -970,7 +970,7 @@ def _final_validate(config):
         if "api" in full_config:
             api_conf = full_config.get("api", {})
             if api_conf.get("encryption"):
-                LOGGER.warning("You may need to disable API encryption to successfully pair with the Nuki Smart Lock, as it consumes quite a bit of memory.")
+                LOGGER.warning("Consider disabling API encryption to successfully pair with the Nuki Smart Lock (it consumes quite a bit of memory and might lead to crashes).")
             
             if not api_conf.get("custom_services", False):
                 LOGGER.warning("Enable custom_services to use API services like 'lock_n_go', 'add_keypad_entry', etc.")

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -14,7 +14,6 @@ from esphome.const import (
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_DOOR,
     DEVICE_CLASS_SWITCH,
-    DEVICE_CLASS_BUTTON,
     DEVICE_CLASS_SIGNAL_STRENGTH,
     UNIT_SECOND,
     UNIT_MINUTE,
@@ -325,13 +324,11 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_UNPAIR_BUTTON): button.button_schema(
                 NukiLockUnpairButton,
-                device_class=DEVICE_CLASS_BUTTON,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:link-off",
             ),
             cv.Optional(CONF_REQUEST_CALIBRATION_BUTTON): button.button_schema(
                 NukiLockRequestCalibrationButton,
-                device_class=DEVICE_CLASS_BUTTON,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:progress-wrench",
             ),

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -964,7 +964,7 @@ def _final_validate(config):
             add_idf_sdkconfig_option("CONFIG_BT_ALLOCATION_FROM_SPIRAM_FIRST", True)
             add_idf_sdkconfig_option("CONFIG_BT_BLE_DYNAMIC_ENV_MEMORY", True)
         else:
-            LOGGER.warning("Consider enabling PSRAM support if it's available for the NimBLE Stack.")
+            LOGGER.warning("Consider enabling PSRAM if available for the NimBLE Stack.")
 
         # Check API configuration
         if "api" in full_config:

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -84,21 +84,21 @@ CONF_SINGLE_LOCKED_POSITION_OFFSET_NUMBER = "single_locked_position_offset"
 CONF_UNLOCKED_TO_LOCKED_TRANSITION_OFFSET_NUMBER = "unlocked_to_locked_transition_offset"
 
 CONF_BUTTON_PRESS_ACTION_SELECT_OPTIONS = [
-    "No Action",
     "Intelligent",
     "Unlock",
     "Lock",
-    "Unlatch",
-    "Lock n Go",
-    "Show Status"
+    "Open door",
+    "Lock 'n' Go",
+    "Show state",
+    "No action",
 ]
 
 CONF_FOB_ACTION_SELECT_OPTIONS = [
-    "No Action",
     "Unlock",
     "Lock",
-    "Lock n Go",
-    "Intelligent"
+    "Lock 'n' Go",
+    "Intelligent",
+    "No action"
 ]
 
 CONF_MOTOR_SPEED_SELECT_OPTIONS = [

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -7,16 +7,21 @@ from esphome.components.esp32 import add_idf_component, add_idf_sdkconfig_option
 from esphome.components import lock, binary_sensor, text_sensor, sensor, switch, button, number, select
 from esphome.const import (
     CONF_ID,
+    CONF_TRIGGER_ID,
+    ENTITY_CATEGORY_CONFIG,
+    ENTITY_CATEGORY_DIAGNOSTIC,
     DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_DOOR,
     DEVICE_CLASS_SWITCH,
+    DEVICE_CLASS_BUTTON,
+    DEVICE_CLASS_LIGHT,
     DEVICE_CLASS_SIGNAL_STRENGTH,
+    UNIT_SECOND,
+    UNIT_MINUTE,
+    UNIT_DEGREES,
     UNIT_PERCENT,
     UNIT_DECIBEL_MILLIWATT,
-    ENTITY_CATEGORY_CONFIG,
-    ENTITY_CATEGORY_DIAGNOSTIC,
-    CONF_TRIGGER_ID,
 )
 import esphome.final_validate as fv
 
@@ -321,21 +326,25 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_UNPAIR_BUTTON): button.button_schema(
                 NukiLockUnpairButton,
+                device_class=DEVICE_CLASS_BUTTON,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:link-off",
             ),
             cv.Optional(CONF_REQUEST_CALIBRATION_BUTTON): button.button_schema(
                 NukiLockRequestCalibrationButton,
+                device_class=DEVICE_CLASS_BUTTON,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:progress-wrench",
             ),
             cv.Optional(CONF_PAIRING_MODE_SWITCH): switch.switch_schema(
                 NukiLockPairingModeSwitch,
+                device_class=DEVICE_CLASS_SWITCH,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:bluetooth"
             ),
             cv.Optional(CONF_PAIRING_ENABLED_SWITCH): switch.switch_schema(
                 NukiLockPairingEnabledSwitch,
+                device_class=DEVICE_CLASS_SWITCH,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:bluetooth"
             ),
@@ -353,7 +362,7 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_LED_ENABLED_SWITCH): switch.switch_schema(
                 NukiLockLedEnabledSwitch,
-                device_class=DEVICE_CLASS_SWITCH,
+                device_class=DEVICE_CLASS_LIGHT,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:led-on"
             ),
@@ -442,41 +451,49 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_TIMEZONE_OFFSET_NUMBER): number.number_schema(
                 NukiLockTimeZoneOffsetNumber,
+                unit_of_measurement=UNIT_MINUTE,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:clock-end",
             ),
             cv.Optional(CONF_LOCK_N_GO_TIMEOUT_NUMBER): number.number_schema(
                 NukiLockLockNGoTimeoutNumber,
+                unit_of_measurement=UNIT_SECOND,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:clock-end",
             ),
             cv.Optional(CONF_AUTO_LOCK_TIMEOUT_NUMBER): number.number_schema(
                 NukiLockAutoLockTimeoutNumber,
+                unit_of_measurement=UNIT_SECOND,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:clock-end",
             ),
             cv.Optional(CONF_UNLATCH_DURATION_NUMBER): number.number_schema(
                 NukiLockUnlatchDurationNumber,
+                unit_of_measurement=UNIT_SECOND,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:clock-end",
             ),
             cv.Optional(CONF_UNLOCKED_POSITION_OFFSET_NUMBER): number.number_schema(
                 NukiLockUnlockedPositionOffsetDegreesNumber,
+                unit_of_measurement=UNIT_DEGREES,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:horizontal-rotate-clockwise",
             ),
             cv.Optional(CONF_LOCKED_POSITION_OFFSET_NUMBER): number.number_schema(
                 NukiLockLockedPositionOffsetDegreesNumber,
+                unit_of_measurement=UNIT_DEGREES,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:horizontal-rotate-clockwise",
             ),
             cv.Optional(CONF_SINGLE_LOCKED_POSITION_OFFSET_NUMBER): number.number_schema(
                 NukiLockSingleLockedPositionOffsetDegreesNumber,
+                unit_of_measurement=UNIT_DEGREES,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:horizontal-rotate-clockwise",
             ),
             cv.Optional(CONF_UNLOCKED_TO_LOCKED_TRANSITION_OFFSET_NUMBER): number.number_schema(
                 NukiLockUnlockedToLockedTransitionOffsetDegreesNumber,
+                unit_of_measurement=UNIT_DEGREES,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:horizontal-rotate-clockwise",
             ),

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -43,7 +43,7 @@ bool NukiLockComponent::nuki_doorsensor_to_binary(Nuki::DoorSensorState nuki_doo
 
 NukiLock::ButtonPressAction NukiLockComponent::button_press_action_to_enum(const char* str)
 {
-    if (strcmp(str, "No Action") == 0) {
+    if (strcmp(str, "No action") == 0) {
         return NukiLock::ButtonPressAction::NoAction;
     } else if (strcmp(str, "Intelligent") == 0) {
         return NukiLock::ButtonPressAction::Intelligent;
@@ -51,11 +51,11 @@ NukiLock::ButtonPressAction NukiLockComponent::button_press_action_to_enum(const
         return NukiLock::ButtonPressAction::Unlock;
     } else if (strcmp(str, "Lock") == 0) {
         return NukiLock::ButtonPressAction::Lock;
-    } else if (strcmp(str, "Unlatch") == 0) {
+    } else if (strcmp(str, "Open door") == 0) {
         return NukiLock::ButtonPressAction::Unlatch;
-    } else if (strcmp(str, "Lock n Go") == 0) {
+    } else if (strcmp(str, "Lock 'n' Go") == 0) {
         return NukiLock::ButtonPressAction::LockNgo;
-    } else if (strcmp(str, "Show Status") == 0) {
+    } else if (strcmp(str, "Show state") == 0) {
         return NukiLock::ButtonPressAction::ShowStatus;
     }
     return NukiLock::ButtonPressAction::NoAction;
@@ -64,7 +64,7 @@ NukiLock::ButtonPressAction NukiLockComponent::button_press_action_to_enum(const
 void NukiLockComponent::button_press_action_to_string(const NukiLock::ButtonPressAction action, char* str) {
     switch (action) {
         case NukiLock::ButtonPressAction::NoAction:
-            strcpy(str, "No Action");
+            strcpy(str, "No action");
             break;
         case NukiLock::ButtonPressAction::Intelligent:
             strcpy(str, "Intelligent");
@@ -76,16 +76,16 @@ void NukiLockComponent::button_press_action_to_string(const NukiLock::ButtonPres
             strcpy(str, "Lock");
             break;
         case NukiLock::ButtonPressAction::Unlatch:
-            strcpy(str, "Unlatch");
+            strcpy(str, "Open door");
             break;
         case NukiLock::ButtonPressAction::LockNgo:
-            strcpy(str, "Lock n Go");
+            strcpy(str, "Lock 'n' Go");
             break;
         case NukiLock::ButtonPressAction::ShowStatus:
-            strcpy(str, "Show Status");
+            strcpy(str, "Show state");
             break;
         default:
-            strcpy(str, "No Action");
+            strcpy(str, "No action");
             break;
     }
 }
@@ -167,13 +167,13 @@ NukiLock::MotorSpeed NukiLockComponent::motor_speed_to_enum(const char* str) {
 }
 
 uint8_t NukiLockComponent::fob_action_to_int(const char *str) {
-    if(strcmp(str, "No Action") == 0) {
+    if(strcmp(str, "No action") == 0) {
         return 0;
     } else if(strcmp(str, "Unlock") == 0) {
         return 1;
     } else if(strcmp(str, "Lock") == 0) {
         return 2;
-    } else if(strcmp(str, "Lock n Go") == 0) {
+    } else if(strcmp(str, "Lock 'n' Go") == 0) {
         return 3;
     } else if(strcmp(str, "Intelligent") == 0) {
         return 4;
@@ -184,7 +184,7 @@ uint8_t NukiLockComponent::fob_action_to_int(const char *str) {
 void NukiLockComponent::fob_action_to_string(const int action, char* str) {
     switch (action) {
         case 0:
-            strcpy(str, "No Action");
+            strcpy(str, "No action");
             break;
         case 1:
             strcpy(str, "Unlock");
@@ -193,13 +193,13 @@ void NukiLockComponent::fob_action_to_string(const int action, char* str) {
             strcpy(str, "Lock");
             break;
         case 3:
-            strcpy(str, "Lock n Go");
+            strcpy(str, "Lock 'n' Go");
             break;
         case 4:
             strcpy(str, "Intelligent");
             break;
         default:
-            strcpy(str, "No Action");
+            strcpy(str, "No action");
             break;
     }
 }

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -799,7 +799,7 @@ void NukiLockComponent::update_advanced_config() {
         }
 
         if (this->detached_cylinder_enabled_switch_ != nullptr) {
-            this->detached_cylinder_enabled_switch_->publish_state(advanced_config.enableDetachedCylinder);
+            this->detached_cylinder_enabled_switch_->publish_state(advanced_config.detachedCylinder);
         }
         #endif
 

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -1371,7 +1371,7 @@ void NukiLockComponent::setup() {
     this->publish_state(lock::LOCK_STATE_NONE);
 
     #ifdef USE_API
-        #ifdef USE_API_SERVICES
+        #ifdef USE_API_CUSTOM_SERVICES
         this->register_service(&NukiLockComponent::lock_n_go, "lock_n_go");
         this->register_service(&NukiLockComponent::print_keypad_entries, "print_keypad_entries");
         this->register_service(&NukiLockComponent::add_keypad_entry, "add_keypad_entry", {"name", "code"});

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -1336,7 +1336,7 @@ void NukiLockComponent::setup() {
             this->event_log_update_ = true;
         }
 
-        const char* pairing_type = this->pairing_as_app_ ? "App" : "Bridge";
+        const char* pairing_type = this->pairing_as_app_.value_or(false) ? "App" : "Bridge";
         const char* lock_type = this->nuki_lock_.isLockUltra() ? "Ultra / Go / 5th Gen" : "1st - 4th Gen";
         ESP_LOGI(TAG, "This component is already paired as %s with a %s smart lock!", pairing_type, lock_type);
 
@@ -1528,7 +1528,7 @@ void NukiLockComponent::update() {
         // Pairing Mode is active
         if (this->pairing_mode_) {
             // Pair Nuki
-            Nuki::AuthorizationIdType type = this->pairing_as_app_ ? Nuki::AuthorizationIdType::App : Nuki::AuthorizationIdType::Bridge;
+            Nuki::AuthorizationIdType type = this->pairing_as_app_.value_or(false) ? Nuki::AuthorizationIdType::App : Nuki::AuthorizationIdType::Bridge;
             
             App.feed_wdt();
             
@@ -1551,7 +1551,7 @@ void NukiLockComponent::update() {
             App.feed_wdt();
 
             if (paired) {
-                const char* pairing_type = this->pairing_as_app_ ? "App" : "Bridge";
+                const char* pairing_type = this->pairing_as_app_.value_or(false) ? "App" : "Bridge";
                 const char* lock_type = this->nuki_lock_.isLockUltra() ? "Ultra / Go / 5th Gen" : "1st - 4th Gen";
                 ESP_LOGI(TAG, "Successfully paired as %s with a %s smart lock!", pairing_type, lock_type);
 
@@ -1805,7 +1805,7 @@ void NukiLockComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  Event: Disabled");
     #endif
 
-    ESP_LOGCONFIG(TAG, "  Pairing Identity: %s",this->pairing_as_app_ ? "App" : "Bridge");
+    ESP_LOGCONFIG(TAG, "  Pairing Identity: %s", this->pairing_as_app_.value_or(false) ? "App" : "Bridge");
     ESP_LOGCONFIG(TAG, "  Is Paired: %s", YESNO(this->is_paired()));
 
     ESP_LOGCONFIG(TAG, "  Pairing mode timeout: %us", this->pairing_mode_timeout_);

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -1531,20 +1531,6 @@ void NukiLockComponent::update() {
             Nuki::AuthorizationIdType type = this->pairing_as_app_.value_or(false) ? Nuki::AuthorizationIdType::App : Nuki::AuthorizationIdType::Bridge;
             
             App.feed_wdt();
-            
-            if (this->security_pin_ != 0) {
-                ESP_LOGW(TAG, "Note: Using security pin override to pair, not yaml config pin!");
-            } else if(this->security_pin_config_.value_or(0) != 0) {
-                ESP_LOGD(TAG, "Using security pin from yaml config to pair.");
-            } else {
-                ESP_LOGW(TAG, "Note: The security pin is crucial to pair a Smart Lock Ultra but is currently not set.");
-            }
-
-            ESP_LOGD(TAG, "NVS pin value (gen 1-4): %d", this->nuki_lock_.getSecurityPincode());
-            ESP_LOGD(TAG, "NVS pin value (ultra/go/gen5): %d", this->nuki_lock_.getUltraPincode());
-
-            ESP_LOGD(TAG, "ESPHome pin value (gen 1-4): %d", this->security_pin_);
-            ESP_LOGD(TAG, "ESPHome pin value (ultra/go/gen5): %d", this->security_pin_config_.value_or(0));
 
             bool paired = this->nuki_lock_.pairNuki(type) == Nuki::PairingResult::Success;
 
@@ -1964,6 +1950,20 @@ void NukiLockComponent::set_pairing_mode(bool enabled) {
     if (enabled) {
         ESP_LOGI(TAG, "Pairing Mode turned on for %d seconds", this->pairing_mode_timeout_);
         this->pairing_mode_on_callback_.call();
+
+        if (this->security_pin_ != 0) {
+            ESP_LOGW(TAG, "Note: Using security pin override to pair, not yaml config pin!");
+        } else if(this->security_pin_config_.value_or(0) != 0) {
+            ESP_LOGD(TAG, "Using security pin from yaml config to pair.");
+        } else {
+            ESP_LOGW(TAG, "Note: The security pin is crucial to pair a Smart Lock Ultra but is currently not set.");
+        }
+
+        ESP_LOGD(TAG, "NVS pin value (gen 1-4): %d", this->nuki_lock_.getSecurityPincode());
+        ESP_LOGD(TAG, "NVS pin value (ultra/go/gen5): %d", this->nuki_lock_.getUltraPincode());
+
+        ESP_LOGD(TAG, "ESPHome pin value (override): %d", this->security_pin_);
+        ESP_LOGD(TAG, "ESPHome pin value (yaml config): %d", this->security_pin_config_.value_or(0));
 
         ESP_LOGI(TAG, "Waiting for Nuki to enter pairing mode...");
 

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -1309,7 +1309,7 @@ void NukiLockComponent::setup() {
         }
     }
 
-    this->nuki_lock_.setDebugConnect(false);
+    this->nuki_lock_.setDebugConnect(true);
     this->nuki_lock_.setDebugCommunication(false);
     this->nuki_lock_.setDebugReadableData(false);
     this->nuki_lock_.setDebugHexData(false);

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -1108,7 +1108,7 @@ const char* NukiLockComponent::get_auth_name(uint32_t authId) const {
 bool NukiLockComponent::execute_lock_action(NukiLock::LockAction lock_action) {
     if (!this->nuki_lock_.isPairedWithLock()) {
         ESP_LOGE(TAG, "Lock is not paired, cannot execute lock action");
-        return;
+        return false;
     }
 
     // Publish the assumed transitional lock state

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -168,7 +168,6 @@ class NukiLockComponent :
         void notify(Nuki::EventType event_type) override;
         float get_setup_priority() const override { return setup_priority::HARDWARE - 1.0f; }
 
-        void set_pairing_as_app(bool pairing_as_app) { this->pairing_as_app_ = pairing_as_app; }
         void set_pairing_mode_timeout(uint32_t pairing_mode_timeout) { this->pairing_mode_timeout_ = pairing_mode_timeout; }
         void set_query_interval_config(uint32_t query_interval_config) { this->query_interval_config_ = query_interval_config; }
         void set_query_interval_auth_data(uint32_t query_interval_auth_data) { this->query_interval_auth_data_ = query_interval_auth_data; }
@@ -182,6 +181,7 @@ class NukiLockComponent :
         }
 
         template<typename T> void set_security_pin_config(T security_pin_config) { this->security_pin_config_ = security_pin_config; }
+        template<typename T> void set_pairing_as_app(T pairing_as_app) { this->pairing_as_app_ = pairing_as_app; }
 
         void add_pairing_mode_on_callback(std::function<void()> &&callback);
         void add_pairing_mode_off_callback(std::function<void()> &&callback);
@@ -286,12 +286,12 @@ class NukiLockComponent :
         bool event_log_update_;
         bool open_latch_;
         bool lock_n_go_;
-
-        bool pairing_as_app_ = false;
-
+        
         PinState pin_state_ = PinState::NotSet;
         uint32_t security_pin_ = 0;
         TemplatableValue<uint32_t> security_pin_config_{};
+
+        TemplatableValue<bool> pairing_as_app_{};
 
         bool connected_ = false;
 

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -166,7 +166,7 @@ class NukiLockComponent :
         void update() override;
         void dump_config() override;
         void notify(Nuki::EventType event_type) override;
-        float get_setup_priority() const override { return setup_priority::HARDWARE; }
+        float get_setup_priority() const override { return setup_priority::AFTER_BLUETOOTH; }
 
         void set_pairing_mode_timeout(uint32_t pairing_mode_timeout) { this->pairing_mode_timeout_ = pairing_mode_timeout; }
         void set_query_interval_config(uint32_t query_interval_config) { this->query_interval_config_ = query_interval_config; }

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -166,7 +166,7 @@ class NukiLockComponent :
         void update() override;
         void dump_config() override;
         void notify(Nuki::EventType event_type) override;
-        float get_setup_priority() const override { return setup_priority::AFTER_BLUETOOTH; }
+        float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
         void set_pairing_mode_timeout(uint32_t pairing_mode_timeout) { this->pairing_mode_timeout_ = pairing_mode_timeout; }
         void set_query_interval_config(uint32_t query_interval_config) { this->query_interval_config_ = query_interval_config; }

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -107,6 +107,8 @@ class NukiLockComponent :
     SUB_NUMBER(led_brightness)
     SUB_NUMBER(timezone_offset)
     SUB_NUMBER(lock_n_go_timeout)
+    SUB_NUMBER(auto_lock_timeout)
+    SUB_NUMBER(unlatch_duration)
     #endif
     #ifdef USE_SELECT
     SUB_SELECT(single_button_press_action)
@@ -121,9 +123,11 @@ class NukiLockComponent :
     #endif
     #ifdef USE_BUTTON
     SUB_BUTTON(unpair)
+    SUB_BUTTON(request_calibration)
     #endif
     #ifdef USE_SWITCH
     SUB_SWITCH(pairing_mode)
+    SUB_SWITCH(pairing_enabled)
     SUB_SWITCH(button_enabled)
     SUB_SWITCH(auto_unlatch_enabled)
     SUB_SWITCH(led_enabled)
@@ -213,6 +217,8 @@ class NukiLockComponent :
         void unpair();
         void set_pairing_mode(bool enabled);
         void save_settings();
+
+        void request_calibration();
 
         bool is_connected() {
             return this->connected_;
@@ -324,6 +330,13 @@ class NukiLockUnpairButton : public button::Button, public Parented<NukiLockComp
     protected:
         void press_action() override;
 };
+
+class NukiLockRequestCalibrationButton : public button::Button, public Parented<NukiLockComponent> {
+    public:
+        NukiLockRequestCalibrationButton() = default;
+    protected:
+        void press_action() override;
+};
 #endif
 
 #ifdef USE_SELECT
@@ -395,6 +408,13 @@ class NukiLockMotorSpeedSelect : public select::Select, public Parented<NukiLock
 class NukiLockPairingModeSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
     public:
         NukiLockPairingModeSwitch() = default;
+    protected:
+        void write_state(bool state) override;
+};
+
+class NukiLockPairingEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
+    public:
+        NukiLockPairingEnabledSwitch() = default;
     protected:
         void write_state(bool state) override;
 };
@@ -538,6 +558,21 @@ class NukiLockTimeZoneOffsetNumber : public number::Number, public Parented<Nuki
 class NukiLockLockNGoTimeoutNumber : public number::Number, public Parented<NukiLockComponent> {
     public:
         NukiLockLockNGoTimeoutNumber() = default;
+
+    protected:
+        void control(float value) override;
+};
+class NukiLockAutoLockTimeoutNumber : public number::Number, public Parented<NukiLockComponent> {
+    public:
+        NukiLockAutoLockTimeoutNumber() = default;
+
+    protected:
+        void control(float value) override;
+};
+
+class NukiLockUnlatchDurationNumber : public number::Number, public Parented<NukiLockComponent> {
+    public:
+        NukiLockUnlatchDurationNumber() = default;
 
     protected:
         void control(float value) override;

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -109,6 +109,10 @@ class NukiLockComponent :
     SUB_NUMBER(lock_n_go_timeout)
     SUB_NUMBER(auto_lock_timeout)
     SUB_NUMBER(unlatch_duration)
+    SUB_NUMBER(unlocked_position_offset)
+    SUB_NUMBER(locked_position_offset)
+    SUB_NUMBER(single_locked_position_offset)
+    SUB_NUMBER(unlocked_to_locked_transition_offset)
     #endif
     #ifdef USE_SELECT
     SUB_SELECT(single_button_press_action)
@@ -143,6 +147,7 @@ class NukiLockComponent :
     SUB_SWITCH(dst_mode_enabled)
     SUB_SWITCH(auto_battery_type_detection_enabled)
     SUB_SWITCH(slow_speed_during_night_mode_enabled)
+    SUB_SWITCH(detached_cylinder_enabled)
     #endif
 
     public:
@@ -538,6 +543,14 @@ class NukiLockSlowSpeedDuringNightModeEnabledSwitch : public switch_::Switch, pu
     protected:
         void write_state(bool state) override;
 };
+
+class NukiLockDetachedCylinderEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
+    public:
+        NukiLockDetachedCylinderEnabledSwitch() = default;
+
+    protected:
+        void write_state(bool state) override;
+};
 #endif
 
 #ifdef USE_NUMBER
@@ -573,6 +586,38 @@ class NukiLockAutoLockTimeoutNumber : public number::Number, public Parented<Nuk
 class NukiLockUnlatchDurationNumber : public number::Number, public Parented<NukiLockComponent> {
     public:
         NukiLockUnlatchDurationNumber() = default;
+
+    protected:
+        void control(float value) override;
+};
+
+class NukiLockUnlockedPositionOffsetDegreesNumber : public number::Number, public Parented<NukiLockComponent> {
+    public:
+        NukiLockUnlockedPositionOffsetDegreesNumber() = default;
+
+    protected:
+        void control(float value) override;
+};
+
+class NukiLockLockedPositionOffsetDegreesNumber : public number::Number, public Parented<NukiLockComponent> {
+    public:
+        NukiLockLockedPositionOffsetDegreesNumber() = default;
+
+    protected:
+        void control(float value) override;
+};
+
+class NukiLockSingleLockedPositionOffsetDegreesNumber : public number::Number, public Parented<NukiLockComponent> {
+    public:
+        NukiLockSingleLockedPositionOffsetDegreesNumber() = default;
+
+    protected:
+        void control(float value) override;
+};
+
+class NukiLockUnlockedToLockedTransitionOffsetDegreesNumber : public number::Number, public Parented<NukiLockComponent> {
+    public:
+        NukiLockUnlockedToLockedTransitionOffsetDegreesNumber() = default;
 
     protected:
         void control(float value) override;

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -166,7 +166,7 @@ class NukiLockComponent :
         void update() override;
         void dump_config() override;
         void notify(Nuki::EventType event_type) override;
-        float get_setup_priority() const override { return setup_priority::HARDWARE - 1.0f; }
+        float get_setup_priority() const override { return setup_priority::AFTER_BLUETOOTH; }
 
         void set_pairing_mode_timeout(uint32_t pairing_mode_timeout) { this->pairing_mode_timeout_ = pairing_mode_timeout; }
         void set_query_interval_config(uint32_t query_interval_config) { this->query_interval_config_ = query_interval_config; }


### PR DESCRIPTION
# General Changes

* Made the `pairing_as_app` option fully templatable.
* Removed outdated Arduino-related code.
* Renamed several example entities for better clarity.

# New Settings

## System

* **Button:** Request Calibration
* **Number:** Unlatch Duration
* **Switch:** Detached Cylinder

## Nuki Lock Button

* **Switch:** Bluetooth Pairing

## Advanced Calibration

* **Number:** Unlocked Position Offset (Degrees)
* **Number:** Locked Position Offset (Degrees)
* **Number:** Single Locked Position Offset (Degrees)
* **Number:** Unlocked → Locked Transition Offset (Degrees)

## Misc

* **Number:** Auto Unlock Timeout

---

Once ready, this will close #95.