### PR TITLE
Use separate task

### DIFF
--- a/.github/shared.yaml
+++ b/.github/shared.yaml
@@ -33,6 +33,20 @@ lock:
   - platform: nuki_lock
     name: Nuki Lock
 
+    pairing_mode_timeout: 300s
+    event: "nuki"
+    security_pin: 1234
+    pairing_as_app: false
+    query_interval_config: 3600s
+    query_interval_auth_data: 7200s
+    ble_general_timeout: 3s
+    ble_command_timeout: 3s
+
+    unpair:
+      name: "Unpair Device"
+    pairing_mode:
+      name: "Pairing Mode"
+
     connected:
       name: "Nuki Connected"
     paired:
@@ -45,7 +59,7 @@ lock:
     battery_level:
       name: "Nuki Battery Level"
     bt_signal_strength:
-      name: "Bluetooth Signal Strength"
+      name: "Nuki Bluetooth Signal Strength"
     
     door_sensor_state:
       name: "Nuki Door Sensor: State"
@@ -58,11 +72,11 @@ lock:
     pin_status:
       name: "Nuki Security Pin Status"
 
-    unpair:
-      name: "Nuki Unpair Device"
+    request_calibration:
+      name: "Nuki Request Calibration"
       
-    pairing_mode:
-      name: "Nuki Pairing Mode"
+    pairing_enabled:
+      name: "Nuki Pairing Enabled"
     auto_unlatch:
       name: "Nuki Auto unlatch"
     button_enabled:
@@ -98,6 +112,10 @@ lock:
       name: "Nuki Timezone: Offset"
     lock_n_go_timeout:
       name: "Nuki LockNGo Timeout"
+    auto_lock_timeout:
+      name: "Nuki Auto Lock Timeout"
+    unlatch_duration:
+      name: "Nuki Unlatch Duration"
 
     single_buton_press_action:
       name: "Nuki Single Button Press Action"
@@ -116,16 +134,6 @@ lock:
     battery_type:
       name: "Nuki Battery Type"
 
-    pairing_mode_timeout: 300s
-    event: "nuki"
-    security_pin: 1234
-    pairing_as_app: false
-    query_interval_config: 3600s
-    query_interval_auth_data: 7200s
-    ble_general_timeout: 3s
-    ble_command_timeout: 3s
-
-
     on_pairing_mode_on_action:
       - lambda: ESP_LOGI("nuki_lock", "Pairing mode turned on");
     on_pairing_mode_off_action:
@@ -141,6 +149,11 @@ button:
     name: Unpair
     on_press:
       - nuki_lock.unpair:
+
+  - platform: template
+    name: Request Calibration
+    on_press:
+      - nuki_lock.request_calibration:
 
   - platform: template
     name: Enable pairing-mode

--- a/.github/shared.yaml
+++ b/.github/shared.yaml
@@ -76,13 +76,13 @@ lock:
       name: "Nuki Request Calibration"
       
     pairing_enabled:
-      name: "Nuki Pairing Enabled"
+      name: "Nuki Button: Bluetooth Pairing"
     auto_unlatch:
       name: "Nuki Auto unlatch"
     button_enabled:
       name: "Nuki Button: Locking operations"
     led_enabled:
-      name: "Nuki LED Signal"
+      name: "Nuki LED: Signal"
     night_mode_enabled:
       name: "Nuki Night Mode"
     night_mode_auto_lock_enabled:
@@ -109,7 +109,7 @@ lock:
       name: "Nuki Detached Cylinder"
 
     led_brightness:
-      name: "Nuki LED Brightness"
+      name: "Nuki LED: Brightness"
     timezone_offset:
       name: "Nuki Timezone: Offset"
     lock_n_go_timeout:

--- a/.github/shared.yaml
+++ b/.github/shared.yaml
@@ -5,7 +5,7 @@ esphome:
         condition:
           nuki_lock.paired:
         then:
-          - lambda: ESP_LOGI("nuki_lock", "Component already paired with Lock");
+          - logger.log: "YAML: Component already paired with Lock"
 
 esp32:
   variant: esp32
@@ -17,6 +17,7 @@ wifi:
 api:
   custom_services: true
   homeassistant_services: true
+  reboot_timeout: 0s
 
 logger:
   level: DEBUG
@@ -145,56 +146,58 @@ lock:
       name: "Nuki Battery Type"
 
     on_pairing_mode_on_action:
-      - lambda: ESP_LOGI("nuki_lock", "Pairing mode turned on");
+      - logger.log: "YAML: Pairing mode turned on"
     on_pairing_mode_off_action:
-      - lambda: ESP_LOGI("nuki_lock", "Pairing mode turned off");
+      - logger.log: "YAML: Pairing mode turned off"
     on_paired_action:
-      - lambda: ESP_LOGI("nuki_lock", "Paired sucessfuly");
+      - logger.log: "YAML: Paired sucessfuly"
     on_event_log_action:
       - lambda: |-
           ESP_LOGI("nuki_lock", "Event Log (NukiLock::LogEntry) received index: %i, authId: %i", x.index, x.authId);
 
 button:
   - platform: template
-    name: Unpair
+    name: Action Test - Unpair
     on_press:
       - nuki_lock.unpair:
 
   - platform: template
-    name: Request Calibration
+    name: Action Test - Request Calibration
     on_press:
       - nuki_lock.request_calibration:
 
   - platform: template
-    name: Enable pairing-mode
+    name: Action Test - Enable pairing-mode
     on_press:
       - nuki_lock.set_pairing_mode:
           pairing_mode: true
 
   - platform: template
-    name: Check connection
+    name: Condition Test - Check connection
     on_press:
       - if:
           condition:
             nuki_lock.connected:
           then:
-            - logger.log: "Lock is connected"
+            - logger.log: "YAML: Lock is connected"
+          else:
+            - logger.log: "YAML: Lock is not connected"
 
   # Set security pin (override)
   # Used instead of yaml config value
   - platform: template
-    name: Override security pin
+    name: Action Test - Override security pin
     on_press:
       - nuki_lock.set_security_pin:
-          security_pin: 5678
+          security_pin: 1234
       # Alernatively using a lambda
       - nuki_lock.set_security_pin:
-          security_pin: !lambda 'return 5678;'
+          security_pin: !lambda 'return 1234;'
 
   # Reset security pin (override)
   # Fallback to yaml config value
   - platform: template
-    name: Reset security pin
+    name: Action Test - Reset security pin
     on_press:
       - nuki_lock.set_security_pin:
           security_pin: 0

--- a/.github/shared.yaml
+++ b/.github/shared.yaml
@@ -35,8 +35,8 @@ lock:
 
     pairing_mode_timeout: 300s
     event: "nuki"
-    security_pin: 1234
-    pairing_as_app: false
+    security_pin: 1234 # templatable
+    pairing_as_app: false # templatable
     query_interval_config: 3600s
     query_interval_auth_data: 7200s
     ble_general_timeout: 3s

--- a/.github/shared.yaml
+++ b/.github/shared.yaml
@@ -105,17 +105,27 @@ lock:
       name: "Nuki Daylight Saving Time"
     auto_battery_type_detection_enabled:
       name: "Nuki Automatic Battery Type Detection"
+    detached_cylinder_enabled:
+      name: "Nuki Detached Cylinder"
 
     led_brightness:
       name: "Nuki LED Brightness"
     timezone_offset:
       name: "Nuki Timezone: Offset"
     lock_n_go_timeout:
-      name: "Nuki LockNGo Timeout"
+      name: "Nuki Lock 'n' Go Timeout"
     auto_lock_timeout:
       name: "Nuki Auto Lock Timeout"
     unlatch_duration:
       name: "Nuki Unlatch Duration"
+    unlocked_position_offset:
+      name: "Nuki Unlocked Position Offset Degrees"
+    locked_position_offset:
+      name: "Nuki Locked Position Offset Degrees"
+    single_locked_position_offset:
+      name: "Nuki Single Locked Position Offset Degrees"
+    unlocked_to_locked_transition_offset:
+      name: "Nuki Unlocked to Locked Transition Offset Degrees"
 
     single_buton_press_action:
       name: "Nuki Single Button Press Action"

--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ Then continue with the pairing instructions below.
 
 2. Before activating pairing mode on the lock, configure ESPHome with:
 
-   * `pairing_as_app: true`
    * `security_pin: 123456`: your 6-digit PIN for the Ultra/Go/5th Gen lock
 
 > [!IMPORTANT]
@@ -262,7 +261,7 @@ The following configuration options allow you to customize the behavior of the N
 | `security_pin`             | Required for event logs & advanced operations (mandatory for Ultra/Go/5th Gen pairing - remove leading zeros: 000548 → 548) | —       |
 | `pairing_mode_timeout`     | Auto-timeout for pairing mode                 | `300s`  |
 | `event`                    | Event log event name (`none` disables logs)   | `none`  |
-| `pairing_as_app`           | Pair as app (required for Ultra/Go/5th Gen)   | `false` |
+| `pairing_as_app`           | Pair as app                                   | `false` |
 | `query_interval_config`    | Config refresh interval                       | `3600s` |
 | `query_interval_auth_data` | Auth data refresh interval                    | `7200s` |
 | `ble_general_timeout`      | General BLE timeout                           | `3s`    |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ lock:
   # Component Settings
   # Change if you want to use event logs
     event: "none"
-    
+
   # Needed to change most of the lock settings
   # Needed to pair with Smart Lock Ultra/5th Gen/Go/Pro (6 digit pin)
   # Supports templating
@@ -75,7 +75,6 @@ lock:
     query_interval_auth_data: 7200s
     ble_general_timeout: 3s
     ble_command_timeout: 3s
-
 
   # Component Entities
   # Switches

--- a/README.md
+++ b/README.md
@@ -122,11 +122,20 @@ lock:
     timezone_offset:
       name: "Nuki Timezone: Offset"
     lock_n_go_timeout:
-      name: "Nuki LockNGo Timeout"
+      name: "Nuki Lock 'n' Go Timeout"
     auto_lock_timeout:
       name: "Nuki Auto Lock Timeout"
     unlatch_duration:
       name: "Nuki Unlatch Duration"
+    # Advanced Calibration
+    unlocked_position_offset:
+      name: "Nuki Unlocked Position Offset Degrees"
+    locked_position_offset:
+      name: "Nuki Locked Position Offset Degrees"
+    single_locked_position_offset:
+      name: "Nuki Single Locked Position Offset Degrees"
+    unlocked_to_locked_transition_offset:
+      name: "Nuki Unlocked to Locked Transition Offset Degrees"
 
   # Optional: Switches
     pairing_enabled:
@@ -161,6 +170,8 @@ lock:
       name: "Nuki Automatic Battery Type Detection"
     slow_speed_during_night_mode_enabled:
       name: "Nuki Slow Speed During Night Mode"
+    detached_cylinder_enabled:
+      name: "Nuki Detached Cylinder"
 
   # Optional: Select Inputs
     single_buton_press_action:
@@ -508,6 +519,7 @@ context:
 - Automatic Updates
 - Automatic Battery Type Detection (Smart Lock Gen 1-4)
 - Slow Speed During Night Mode (Smart Lock Ultra)
+- Detached Cylinder
 
 **Button:**  
 - Request Calibration
@@ -526,9 +538,13 @@ context:
 **Number Input:**  
 - LED Brightness
 - Timezone Offset
-- LockNGo Timeout
+- Lock 'n' Go Timeout
 - Auto Lock Timeout
 - Unlatch Duration
+- Unlocked Position Offset Degrees
+- Locked Position Offset Degrees
+- Single Locked Position Offset Degrees
+- Unlocked to Locked Transition Offset Degrees
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ lock:
     battery_level:
       name: "Nuki Battery Level"
     bt_signal_strength:
-      name: "Bluetooth Signal Strength"
+      name: "Nuki Bluetooth Signal Strength"
 
   # Optional: Text Sensors
     door_sensor_state:
@@ -123,8 +123,14 @@ lock:
       name: "Nuki Timezone: Offset"
     lock_n_go_timeout:
       name: "Nuki LockNGo Timeout"
+    auto_lock_timeout:
+      name: "Nuki Auto Lock Timeout"
+    unlatch_duration:
+      name: "Nuki Unlatch Duration"
 
   # Optional: Switches
+    pairing_enabled:
+      name: "Nuki Pairing Enabled"
     auto_unlatch:
       name: "Nuki Auto unlatch"
     button_enabled:
@@ -338,6 +344,13 @@ on_...:
   - nuki_lock.unpair:
 ```
 
+## Action: Request Calibration
+To request a calibration of your Nuki Smart Lock, use the following action:
+```yaml
+on_...:
+  - nuki_lock.request_calibration:
+```
+
 ## Action: Security Pin
 
 > [!CAUTION]  
@@ -480,6 +493,7 @@ context:
 - Last Lock Action Trigger
 
 **Switch:**  
+- Pairing Enabled
 - Button Enabled
 - LED Enabled
 - Night Mode
@@ -495,6 +509,9 @@ context:
 - Automatic Battery Type Detection (Smart Lock Gen 1-4)
 - Slow Speed During Night Mode (Smart Lock Ultra)
 
+**Button:**  
+- Request Calibration
+
 **Select Input:**  
 - Single Button Press Action
 - Double Button Press Action
@@ -509,6 +526,9 @@ context:
 **Number Input:**  
 - LED Brightness
 - Timezone Offset
+- LockNGo Timeout
+- Auto Lock Timeout
+- Unlatch Duration
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESPHome Nuki Lock Component (ESP32) [![Build Component](https://github.com/uriyacovy/ESPHome_nuki_lock/actions/workflows/build.yaml/badge.svg)](https://github.com/uriyacovy/ESPHome_nuki_lock/actions/workflows/build.yaml)
 
-Seamlessly integrate Nuki Smart Locks (1st–5th Gen, Ultra, Go) with ESPHome, enabling a full-featured Home Assistant lock platform with [many available entities](#-entities).
+Seamlessly integrate Nuki Smart Locks (1st–5th Gen, Ultra, Go, Pro) with ESPHome, enabling a full-featured Home Assistant lock platform with [many available entities](#-entities).
 The lock state is always up-to-date thanks to Nuki's BLE advertisement mechanism—whether controlled through the Nuki app, Home Assistant, or physically at the door.
 
 ![some dashboard entites](./docs/nuki_dashboard.png)
@@ -64,7 +64,7 @@ lock:
     event: "none"
     
   # Needed to change most of the lock settings
-  # Needed to pair with Smart Lock Ultra/5th Gen/Go (6 digit pin)
+  # Needed to pair with Smart Lock Ultra/5th Gen/Go/Pro (6 digit pin)
   # Supports templating
     security_pin: 1234
 
@@ -217,7 +217,7 @@ Then continue with the pairing instructions below.
 
 # 🔐 Pairing Your Nuki Lock
 
-## Pairing with Nuki Lock (1st–4th Gen)
+## Pairing with Nuki Smart Lock (1st – 4th Gen)
 
 1. In the official Nuki App, make sure **Bluetooth pairing** is enabled:  
    **Settings → Features & Configuration → Button and LED**.  
@@ -231,14 +231,14 @@ Then continue with the pairing instructions below.
 > [!NOTE]  
 > The ESPHome bridge *can* run alongside an official Nuki Bridge, but this is not recommended (except in hybrid mode). Running both may increase battery drain and cause missed updates. If you need both, set `pairing_as_app: true` **before pairing**. Otherwise, pairing with the ESPHome bridge will unregister the official Bridge.
 
-## Pairing with Nuki Lock Ultra / Nuki Lock Go / Nuki Lock 5th Gen Pro
+## Pairing with Nuki Smart Lock Ultra / 5th Gen / Go / Pro
 
 1. In the official Nuki App, ensure **Bluetooth pairing** is enabled:  
    **Settings → Features & Configuration → Button and LED**.
 
 2. Before activating pairing mode on the lock, configure ESPHome with:
 
-   * `security_pin: 123456`: your 6-digit PIN for the Ultra/Go/5th Gen lock
+   * `security_pin: 123456`: your 6-digit PIN for the Nuki Smart Lock Ultra/5th Gen/Go/Pro
 
 > [!IMPORTANT]
 > If your PIN starts with zeros, remove them (e.g., 000548 → 548). Pairing will fail if you include leading zeros.
@@ -258,7 +258,7 @@ The following configuration options allow you to customize the behavior of the N
 
 | Option                     | Description                                   | Default |
 | -------------------------- | --------------------------------------------- | ------- |
-| `security_pin`             | Required for event logs & advanced operations (mandatory for Ultra/Go/5th Gen pairing - remove leading zeros: 000548 → 548) | —       |
+| `security_pin`             | Required for event logs & advanced operations (mandatory for Ultra/5th Gen/Go/Pro pairing - remove leading zeros: 000548 → 548) | —       |
 | `pairing_mode_timeout`     | Auto-timeout for pairing mode                 | `300s`  |
 | `event`                    | Event log event name (`none` disables logs)   | `none`  |
 | `pairing_as_app`           | Pair as app                                   | `false` |

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ lock:
 
   # Optional: Number Inputs
     led_brightness:
-      name: "Nuki LED Brightness"
+      name: "Nuki LED: Brightness"
     timezone_offset:
       name: "Nuki Timezone: Offset"
     lock_n_go_timeout:
@@ -139,13 +139,13 @@ lock:
 
   # Optional: Switches
     pairing_enabled:
-      name: "Nuki Pairing Enabled"
+      name: "Nuki Button: Bluetooth Pairing"
     auto_unlatch:
       name: "Nuki Auto unlatch"
     button_enabled:
       name: "Nuki Button: Locking operations"
     led_enabled:
-      name: "Nuki LED Signal"
+      name: "Nuki LED: Signal"
     night_mode_enabled:
       name: "Nuki Night Mode"
     night_mode_auto_lock_enabled:
@@ -504,9 +504,9 @@ context:
 - Last Lock Action Trigger
 
 **Switch:**  
-- Pairing Enabled
-- Button Enabled
-- LED Enabled
+- Button: Bluetooth Pairing
+- Button: Locking operations
+- LED Signal
 - Night Mode
 - Night Mode: Auto Lock
 - Night Mode: Reject Auto Unlock
@@ -536,7 +536,7 @@ context:
 - Motor Speed (Smart Lock Ultra)
 
 **Number Input:**  
-- LED Brightness
+- LED: Brightness
 - Timezone Offset
 - Lock 'n' Go Timeout
 - Auto Lock Timeout

--- a/components/nuki_lock/automation.h
+++ b/components/nuki_lock/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "nuki_lock.h"
 
-namespace esphome {
-namespace nuki_lock {
+namespace esphome::nuki_lock {
 
 // Actions
 template<typename... Ts>
@@ -85,5 +84,4 @@ class EventLogReceivedTrigger : public Trigger<NukiLock::LogEntry> {
         }
 };
 
-} //namespace nuki_lock
-} //namespace esphome
+}

--- a/components/nuki_lock/automation.h
+++ b/components/nuki_lock/automation.h
@@ -15,6 +15,12 @@ class NukiLockUnpairAction : public Action<Ts...>, public Parented<NukiLockCompo
 };
 
 template<typename... Ts>
+class NukiLockRequestCalibrationAction : public Action<Ts...>, public Parented<NukiLockComponent> {
+    public:
+        void play(const Ts&... x) override { this->parent_->request_calibration(); }
+};
+
+template<typename... Ts>
 class NukiLockPairingModeAction : public Action<Ts...>, public Parented<NukiLockComponent> {
     TEMPLATABLE_VALUE(bool, pairing_mode)
 

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -15,7 +15,6 @@ from esphome.const import (
     DEVICE_CLASS_DOOR,
     DEVICE_CLASS_SWITCH,
     DEVICE_CLASS_BUTTON,
-    DEVICE_CLASS_LIGHT,
     DEVICE_CLASS_SIGNAL_STRENGTH,
     UNIT_SECOND,
     UNIT_MINUTE,
@@ -362,7 +361,7 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_LED_ENABLED_SWITCH): switch.switch_schema(
                 NukiLockLedEnabledSwitch,
-                device_class=DEVICE_CLASS_LIGHT,
+                device_class=DEVICE_CLASS_SWITCH,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:led-on"
             ),

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -170,13 +170,13 @@ CONF_BATTERY_TYPE_SELECT_OPTIONS = [
     "Lithium"
 ]
 
-CONF_PAIRING_MODE_TIMEOUT = "pairing_mode_timeout"
 CONF_PAIRING_AS_APP = "pairing_as_app"
 CONF_SECURITY_PIN = "security_pin"
 CONF_QUERY_INTERVAL_CONFIG = "query_interval_config"
 CONF_QUERY_INTERVAL_AUTH_DATA = "query_interval_auth_data"
 CONF_BLE_GENERAL_TIMEOUT = "ble_general_timeout"
 CONF_BLE_COMMAND_TIMEOUT = "ble_command_timeout"
+CONF_PAIRING_MODE_TIMEOUT = "pairing_mode_timeout"
 CONF_EVENT = "event"
 
 CONF_ON_PAIRING_MODE_ON = "on_pairing_mode_on_action"
@@ -568,7 +568,6 @@ CONFIG_SCHEMA = cv.All(
             ),
         }
     )
-    .extend(cv.polling_component_schema("500ms")),
 )
 
 

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -908,6 +908,24 @@ async def to_code(config):
 
     # Libraries
     add_idf_component(
+        name="espressif/libsodium",
+        ref="^1.0.20~2",
+    )
+    add_idf_component(
+        name="crc16",
+        repo="https://github.com/AzonInc/Crc16.git",
+    )
+    add_idf_component(
+        name="ble-scanner",
+        repo="https://github.com/AzonInc/ble-scanner.git",
+        ref="2.1.0",
+    )
+    add_idf_component(
+        name="esp-nimble-cpp",
+        repo="https://github.com/h2zero/esp-nimble-cpp.git",
+        ref="2.3.3",
+    )
+    add_idf_component(
         name="NukiBleEsp32",
         repo="https://github.com/AzonInc/NukiBleEsp32.git",
         ref="idf",

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -970,7 +970,7 @@ def _final_validate(config):
         if "api" in full_config:
             api_conf = full_config.get("api", {})
             if api_conf.get("encryption"):
-                LOGGER.warning("You may need to disable API encryption to successfully pair with the Nuki Smart Lock, as it consumes quite a bit of memory.")
+                LOGGER.warning("Consider disabling API encryption to successfully pair with the Nuki Smart Lock (it consumes quite a bit of memory and might lead to crashes).")
             
             if not api_conf.get("custom_services", False):
                 LOGGER.warning("Enable custom_services to use API services like 'lock_n_go', 'add_keypad_entry', etc.")

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -14,7 +14,6 @@ from esphome.const import (
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_DOOR,
     DEVICE_CLASS_SWITCH,
-    DEVICE_CLASS_BUTTON,
     DEVICE_CLASS_SIGNAL_STRENGTH,
     UNIT_SECOND,
     UNIT_MINUTE,
@@ -325,13 +324,11 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_UNPAIR_BUTTON): button.button_schema(
                 NukiLockUnpairButton,
-                device_class=DEVICE_CLASS_BUTTON,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:link-off",
             ),
             cv.Optional(CONF_REQUEST_CALIBRATION_BUTTON): button.button_schema(
                 NukiLockRequestCalibrationButton,
-                device_class=DEVICE_CLASS_BUTTON,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:progress-wrench",
             ),

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -964,7 +964,7 @@ def _final_validate(config):
             add_idf_sdkconfig_option("CONFIG_BT_ALLOCATION_FROM_SPIRAM_FIRST", True)
             add_idf_sdkconfig_option("CONFIG_BT_BLE_DYNAMIC_ENV_MEMORY", True)
         else:
-            LOGGER.warning("Consider enabling PSRAM support if it's available for the NimBLE Stack.")
+            LOGGER.warning("Consider enabling PSRAM if available for the NimBLE Stack.")
 
         # Check API configuration
         if "api" in full_config:

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -84,21 +84,21 @@ CONF_SINGLE_LOCKED_POSITION_OFFSET_NUMBER = "single_locked_position_offset"
 CONF_UNLOCKED_TO_LOCKED_TRANSITION_OFFSET_NUMBER = "unlocked_to_locked_transition_offset"
 
 CONF_BUTTON_PRESS_ACTION_SELECT_OPTIONS = [
-    "No Action",
     "Intelligent",
     "Unlock",
     "Lock",
-    "Unlatch",
-    "Lock n Go",
-    "Show Status"
+    "Open door",
+    "Lock 'n' Go",
+    "Show state",
+    "No action",
 ]
 
 CONF_FOB_ACTION_SELECT_OPTIONS = [
-    "No Action",
     "Unlock",
     "Lock",
-    "Lock n Go",
-    "Intelligent"
+    "Lock 'n' Go",
+    "Intelligent",
+    "No action"
 ]
 
 CONF_MOTOR_SPEED_SELECT_OPTIONS = [

--- a/components/nuki_lock/lock.py
+++ b/components/nuki_lock/lock.py
@@ -7,16 +7,21 @@ from esphome.components.esp32 import add_idf_component, add_idf_sdkconfig_option
 from esphome.components import lock, binary_sensor, text_sensor, sensor, switch, button, number, select
 from esphome.const import (
     CONF_ID,
+    CONF_TRIGGER_ID,
+    ENTITY_CATEGORY_CONFIG,
+    ENTITY_CATEGORY_DIAGNOSTIC,
     DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_DOOR,
     DEVICE_CLASS_SWITCH,
+    DEVICE_CLASS_BUTTON,
+    DEVICE_CLASS_LIGHT,
     DEVICE_CLASS_SIGNAL_STRENGTH,
+    UNIT_SECOND,
+    UNIT_MINUTE,
+    UNIT_DEGREES,
     UNIT_PERCENT,
     UNIT_DECIBEL_MILLIWATT,
-    ENTITY_CATEGORY_CONFIG,
-    ENTITY_CATEGORY_DIAGNOSTIC,
-    CONF_TRIGGER_ID,
 )
 import esphome.final_validate as fv
 
@@ -321,21 +326,25 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_UNPAIR_BUTTON): button.button_schema(
                 NukiLockUnpairButton,
+                device_class=DEVICE_CLASS_BUTTON,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:link-off",
             ),
             cv.Optional(CONF_REQUEST_CALIBRATION_BUTTON): button.button_schema(
                 NukiLockRequestCalibrationButton,
+                device_class=DEVICE_CLASS_BUTTON,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:progress-wrench",
             ),
             cv.Optional(CONF_PAIRING_MODE_SWITCH): switch.switch_schema(
                 NukiLockPairingModeSwitch,
+                device_class=DEVICE_CLASS_SWITCH,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:bluetooth"
             ),
             cv.Optional(CONF_PAIRING_ENABLED_SWITCH): switch.switch_schema(
                 NukiLockPairingEnabledSwitch,
+                device_class=DEVICE_CLASS_SWITCH,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:bluetooth"
             ),
@@ -353,7 +362,7 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_LED_ENABLED_SWITCH): switch.switch_schema(
                 NukiLockLedEnabledSwitch,
-                device_class=DEVICE_CLASS_SWITCH,
+                device_class=DEVICE_CLASS_LIGHT,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:led-on"
             ),
@@ -442,41 +451,49 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_TIMEZONE_OFFSET_NUMBER): number.number_schema(
                 NukiLockTimeZoneOffsetNumber,
+                unit_of_measurement=UNIT_MINUTE,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:clock-end",
             ),
             cv.Optional(CONF_LOCK_N_GO_TIMEOUT_NUMBER): number.number_schema(
                 NukiLockLockNGoTimeoutNumber,
+                unit_of_measurement=UNIT_SECOND,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:clock-end",
             ),
             cv.Optional(CONF_AUTO_LOCK_TIMEOUT_NUMBER): number.number_schema(
                 NukiLockAutoLockTimeoutNumber,
+                unit_of_measurement=UNIT_SECOND,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:clock-end",
             ),
             cv.Optional(CONF_UNLATCH_DURATION_NUMBER): number.number_schema(
                 NukiLockUnlatchDurationNumber,
+                unit_of_measurement=UNIT_SECOND,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:clock-end",
             ),
             cv.Optional(CONF_UNLOCKED_POSITION_OFFSET_NUMBER): number.number_schema(
                 NukiLockUnlockedPositionOffsetDegreesNumber,
+                unit_of_measurement=UNIT_DEGREES,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:horizontal-rotate-clockwise",
             ),
             cv.Optional(CONF_LOCKED_POSITION_OFFSET_NUMBER): number.number_schema(
                 NukiLockLockedPositionOffsetDegreesNumber,
+                unit_of_measurement=UNIT_DEGREES,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:horizontal-rotate-clockwise",
             ),
             cv.Optional(CONF_SINGLE_LOCKED_POSITION_OFFSET_NUMBER): number.number_schema(
                 NukiLockSingleLockedPositionOffsetDegreesNumber,
+                unit_of_measurement=UNIT_DEGREES,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:horizontal-rotate-clockwise",
             ),
             cv.Optional(CONF_UNLOCKED_TO_LOCKED_TRANSITION_OFFSET_NUMBER): number.number_schema(
                 NukiLockUnlockedToLockedTransitionOffsetDegreesNumber,
+                unit_of_measurement=UNIT_DEGREES,
                 entity_category=ENTITY_CATEGORY_CONFIG,
                 icon="mdi:horizontal-rotate-clockwise",
             ),

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -43,7 +43,7 @@ bool NukiLockComponent::nuki_doorsensor_to_binary(Nuki::DoorSensorState nuki_doo
 
 NukiLock::ButtonPressAction NukiLockComponent::button_press_action_to_enum(const char* str)
 {
-    if (strcmp(str, "No Action") == 0) {
+    if (strcmp(str, "No action") == 0) {
         return NukiLock::ButtonPressAction::NoAction;
     } else if (strcmp(str, "Intelligent") == 0) {
         return NukiLock::ButtonPressAction::Intelligent;
@@ -51,11 +51,11 @@ NukiLock::ButtonPressAction NukiLockComponent::button_press_action_to_enum(const
         return NukiLock::ButtonPressAction::Unlock;
     } else if (strcmp(str, "Lock") == 0) {
         return NukiLock::ButtonPressAction::Lock;
-    } else if (strcmp(str, "Unlatch") == 0) {
+    } else if (strcmp(str, "Open door") == 0) {
         return NukiLock::ButtonPressAction::Unlatch;
-    } else if (strcmp(str, "Lock n Go") == 0) {
+    } else if (strcmp(str, "Lock 'n' Go") == 0) {
         return NukiLock::ButtonPressAction::LockNgo;
-    } else if (strcmp(str, "Show Status") == 0) {
+    } else if (strcmp(str, "Show state") == 0) {
         return NukiLock::ButtonPressAction::ShowStatus;
     }
     return NukiLock::ButtonPressAction::NoAction;
@@ -64,7 +64,7 @@ NukiLock::ButtonPressAction NukiLockComponent::button_press_action_to_enum(const
 void NukiLockComponent::button_press_action_to_string(const NukiLock::ButtonPressAction action, char* str) {
     switch (action) {
         case NukiLock::ButtonPressAction::NoAction:
-            strcpy(str, "No Action");
+            strcpy(str, "No action");
             break;
         case NukiLock::ButtonPressAction::Intelligent:
             strcpy(str, "Intelligent");
@@ -76,16 +76,16 @@ void NukiLockComponent::button_press_action_to_string(const NukiLock::ButtonPres
             strcpy(str, "Lock");
             break;
         case NukiLock::ButtonPressAction::Unlatch:
-            strcpy(str, "Unlatch");
+            strcpy(str, "Open door");
             break;
         case NukiLock::ButtonPressAction::LockNgo:
-            strcpy(str, "Lock n Go");
+            strcpy(str, "Lock 'n' Go");
             break;
         case NukiLock::ButtonPressAction::ShowStatus:
-            strcpy(str, "Show Status");
+            strcpy(str, "Show state");
             break;
         default:
-            strcpy(str, "No Action");
+            strcpy(str, "No action");
             break;
     }
 }
@@ -167,13 +167,13 @@ NukiLock::MotorSpeed NukiLockComponent::motor_speed_to_enum(const char* str) {
 }
 
 uint8_t NukiLockComponent::fob_action_to_int(const char *str) {
-    if(strcmp(str, "No Action") == 0) {
+    if(strcmp(str, "No action") == 0) {
         return 0;
     } else if(strcmp(str, "Unlock") == 0) {
         return 1;
     } else if(strcmp(str, "Lock") == 0) {
         return 2;
-    } else if(strcmp(str, "Lock n Go") == 0) {
+    } else if(strcmp(str, "Lock 'n' Go") == 0) {
         return 3;
     } else if(strcmp(str, "Intelligent") == 0) {
         return 4;
@@ -184,7 +184,7 @@ uint8_t NukiLockComponent::fob_action_to_int(const char *str) {
 void NukiLockComponent::fob_action_to_string(const int action, char* str) {
     switch (action) {
         case 0:
-            strcpy(str, "No Action");
+            strcpy(str, "No action");
             break;
         case 1:
             strcpy(str, "Unlock");
@@ -193,13 +193,13 @@ void NukiLockComponent::fob_action_to_string(const int action, char* str) {
             strcpy(str, "Lock");
             break;
         case 3:
-            strcpy(str, "Lock n Go");
+            strcpy(str, "Lock 'n' Go");
             break;
         case 4:
             strcpy(str, "Intelligent");
             break;
         default:
-            strcpy(str, "No Action");
+            strcpy(str, "No action");
             break;
     }
 }

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -799,7 +799,7 @@ void NukiLockComponent::update_advanced_config() {
         }
 
         if (this->detached_cylinder_enabled_switch_ != nullptr) {
-            this->detached_cylinder_enabled_switch_->publish_state(advanced_config.enableDetachedCylinder);
+            this->detached_cylinder_enabled_switch_->publish_state(advanced_config.detachedCylinder);
         }
         #endif
 

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -9,504 +9,11 @@
 #include <map>
 
 #include "nuki_lock.h"
+#include "utils.h"
 
-namespace esphome {
-namespace nuki_lock {
+namespace esphome::nuki_lock {
 
 uint32_t global_nuki_lock_id = 1912044075ULL;
-
-lock::LockState NukiLockComponent::nuki_to_lock_state(NukiLock::LockState nukiLockState) {
-    switch(nukiLockState) {
-        case NukiLock::LockState::Locked:
-            return lock::LOCK_STATE_LOCKED;
-        case NukiLock::LockState::Unlocked:
-        case NukiLock::LockState::Unlatched:
-            return lock::LOCK_STATE_UNLOCKED;
-        case NukiLock::LockState::MotorBlocked:
-            return lock::LOCK_STATE_JAMMED;
-        case NukiLock::LockState::Locking:
-            return lock::LOCK_STATE_LOCKING;
-        case NukiLock::LockState::Unlocking:
-        case NukiLock::LockState::Unlatching:
-            return lock::LOCK_STATE_UNLOCKING;
-        default:
-            return lock::LOCK_STATE_NONE;
-    }
-}
-
-bool NukiLockComponent::nuki_doorsensor_to_binary(Nuki::DoorSensorState nuki_door_sensor_state) {
-    if (nuki_door_sensor_state == Nuki::DoorSensorState::DoorClosed) {
-        return false;
-    }
-    return true;
-}
-
-NukiLock::ButtonPressAction NukiLockComponent::button_press_action_to_enum(const char* str)
-{
-    if (strcmp(str, "No action") == 0) {
-        return NukiLock::ButtonPressAction::NoAction;
-    } else if (strcmp(str, "Intelligent") == 0) {
-        return NukiLock::ButtonPressAction::Intelligent;
-    } else if (strcmp(str, "Unlock") == 0) {
-        return NukiLock::ButtonPressAction::Unlock;
-    } else if (strcmp(str, "Lock") == 0) {
-        return NukiLock::ButtonPressAction::Lock;
-    } else if (strcmp(str, "Open door") == 0) {
-        return NukiLock::ButtonPressAction::Unlatch;
-    } else if (strcmp(str, "Lock 'n' Go") == 0) {
-        return NukiLock::ButtonPressAction::LockNgo;
-    } else if (strcmp(str, "Show state") == 0) {
-        return NukiLock::ButtonPressAction::ShowStatus;
-    }
-    return NukiLock::ButtonPressAction::NoAction;
-}
-
-void NukiLockComponent::button_press_action_to_string(const NukiLock::ButtonPressAction action, char* str) {
-    switch (action) {
-        case NukiLock::ButtonPressAction::NoAction:
-            strcpy(str, "No action");
-            break;
-        case NukiLock::ButtonPressAction::Intelligent:
-            strcpy(str, "Intelligent");
-            break;
-        case NukiLock::ButtonPressAction::Unlock:
-            strcpy(str, "Unlock");
-            break;
-        case NukiLock::ButtonPressAction::Lock:
-            strcpy(str, "Lock");
-            break;
-        case NukiLock::ButtonPressAction::Unlatch:
-            strcpy(str, "Open door");
-            break;
-        case NukiLock::ButtonPressAction::LockNgo:
-            strcpy(str, "Lock 'n' Go");
-            break;
-        case NukiLock::ButtonPressAction::ShowStatus:
-            strcpy(str, "Show state");
-            break;
-        default:
-            strcpy(str, "No action");
-            break;
-    }
-}
-
-void NukiLockComponent::battery_type_to_string(const Nuki::BatteryType battery_type, char* str) {
-    switch (battery_type) {
-        case Nuki::BatteryType::Alkali:
-            strcpy(str, "Alkali");
-            break;
-        case Nuki::BatteryType::Accumulators:
-            strcpy(str, "Accumulators");
-            break;
-        case Nuki::BatteryType::Lithium:
-            strcpy(str, "Lithium");
-            break;
-        default:
-            strcpy(str, "undefined");
-            break;
-    }
-}
-
-Nuki::BatteryType NukiLockComponent::battery_type_to_enum(const char* str) {
-    if(strcmp(str, "Alkali") == 0) {
-        return Nuki::BatteryType::Alkali;
-    } else if(strcmp(str, "Accumulators") == 0) {
-        return Nuki::BatteryType::Accumulators;
-    } else if(strcmp(str, "Lithium") == 0) {
-        return Nuki::BatteryType::Lithium;
-    }
-    return (Nuki::BatteryType)0xff;
-}
-
-void NukiLockComponent::homekit_status_to_string(const int status, char* str) {
-    switch (status) {
-        case 0:
-            strcpy(str, "Not Available");
-            break;
-        case 1:
-            strcpy(str, "Disabled");
-            break;
-        case 2:
-            strcpy(str, "Enabled");
-            break;
-        case 3:
-            strcpy(str, "Enabled & Paired");
-            break;
-        default:
-            strcpy(str, "undefined");
-            break;
-    }
-}
-
-void NukiLockComponent::motor_speed_to_string(const NukiLock::MotorSpeed speed, char* str) {
-    switch (speed) {
-        case NukiLock::MotorSpeed::Standard:
-            strcpy(str, "Standard");
-            break;
-        case NukiLock::MotorSpeed::Insane:
-            strcpy(str, "Insane");
-            break;
-        case NukiLock::MotorSpeed::Gentle:
-            strcpy(str, "Gentle");
-            break;
-        default:
-            strcpy(str, "undefined");
-            break;
-    }
-}
-
-NukiLock::MotorSpeed NukiLockComponent::motor_speed_to_enum(const char* str) {
-    if(strcmp(str, "Standard") == 0) {
-        return NukiLock::MotorSpeed::Standard;
-    } else if(strcmp(str, "Insane") == 0) {
-        return NukiLock::MotorSpeed::Insane;
-    } else if(strcmp(str, "Gentle") == 0) {
-        return NukiLock::MotorSpeed::Gentle;
-    }
-    return NukiLock::MotorSpeed::Standard;
-}
-
-uint8_t NukiLockComponent::fob_action_to_int(const char *str) {
-    if(strcmp(str, "No action") == 0) {
-        return 0;
-    } else if(strcmp(str, "Unlock") == 0) {
-        return 1;
-    } else if(strcmp(str, "Lock") == 0) {
-        return 2;
-    } else if(strcmp(str, "Lock 'n' Go") == 0) {
-        return 3;
-    } else if(strcmp(str, "Intelligent") == 0) {
-        return 4;
-    }
-    return 99;
-}
-
-void NukiLockComponent::fob_action_to_string(const int action, char* str) {
-    switch (action) {
-        case 0:
-            strcpy(str, "No action");
-            break;
-        case 1:
-            strcpy(str, "Unlock");
-            break;
-        case 2:
-            strcpy(str, "Lock");
-            break;
-        case 3:
-            strcpy(str, "Lock 'n' Go");
-            break;
-        case 4:
-            strcpy(str, "Intelligent");
-            break;
-        default:
-            strcpy(str, "No action");
-            break;
-    }
-}
-
-Nuki::TimeZoneId NukiLockComponent::timezone_to_enum(const char *str) {
-    if(strcmp(str, "Africa/Cairo") == 0) {
-        return Nuki::TimeZoneId::Africa_Cairo;
-    } else if(strcmp(str, "Africa/Lagos") == 0) {
-        return Nuki::TimeZoneId::Africa_Lagos;
-    } else if(strcmp(str, "Africa/Maputo") == 0) {
-        return Nuki::TimeZoneId::Africa_Maputo;
-    } else if(strcmp(str, "Africa/Nairobi") == 0) {
-        return Nuki::TimeZoneId::Africa_Nairobi;
-    } else if(strcmp(str, "America/Anchorage") == 0) {
-        return Nuki::TimeZoneId::America_Anchorage;
-    } else if(strcmp(str, "America/Argentina/Buenos_Aires") == 0) {
-        return Nuki::TimeZoneId::America_Argentina_Buenos_Aires;
-    } else if(strcmp(str, "America/Chicago") == 0) {
-        return Nuki::TimeZoneId::America_Chicago;
-    } else if(strcmp(str, "America/Denver") == 0) {
-        return Nuki::TimeZoneId::America_Denver;
-    } else if(strcmp(str, "America/Halifax") == 0) {
-        return Nuki::TimeZoneId::America_Halifax;
-    } else if(strcmp(str, "America/Los_Angeles") == 0) {
-        return Nuki::TimeZoneId::America_Los_Angeles;
-    } else if(strcmp(str, "America/Manaus") == 0) {
-        return Nuki::TimeZoneId::America_Manaus;
-    } else if(strcmp(str, "America/Mexico_City") == 0) {
-        return Nuki::TimeZoneId::America_Mexico_City;
-    } else if(strcmp(str, "America/New_York") == 0) {
-        return Nuki::TimeZoneId::America_New_York;
-    } else if(strcmp(str, "America/Phoenix") == 0) {
-        return Nuki::TimeZoneId::America_Phoenix;
-    } else if(strcmp(str, "America/Regina") == 0) {
-        return Nuki::TimeZoneId::America_Regina;
-    } else if(strcmp(str, "America/Santiago") == 0) {
-        return Nuki::TimeZoneId::America_Santiago;
-    } else if(strcmp(str, "America/Sao_Paulo") == 0) {
-        return Nuki::TimeZoneId::America_Sao_Paulo;
-    } else if(strcmp(str, "America/St_Johns") == 0) {
-        return Nuki::TimeZoneId::America_St_Johns;
-    } else if(strcmp(str, "Asia/Bangkok") == 0) {
-        return Nuki::TimeZoneId::Asia_Bangkok;
-    } else if(strcmp(str, "Asia/Dubai") == 0) {
-        return Nuki::TimeZoneId::Asia_Dubai;
-    } else if(strcmp(str, "Asia/Hong_Kong") == 0) {
-        return Nuki::TimeZoneId::Asia_Hong_Kong;
-    } else if(strcmp(str, "Asia/Jerusalem") == 0) {
-        return Nuki::TimeZoneId::Asia_Jerusalem;
-    } else if(strcmp(str, "Asia/Karachi") == 0) {
-        return Nuki::TimeZoneId::Asia_Karachi;
-    } else if(strcmp(str, "Asia/Kathmandu") == 0) {
-        return Nuki::TimeZoneId::Asia_Kathmandu;
-    } else if(strcmp(str, "Asia/Kolkata") == 0) {
-        return Nuki::TimeZoneId::Asia_Kolkata;
-    } else if(strcmp(str, "Asia/Riyadh") == 0) {
-        return Nuki::TimeZoneId::Asia_Riyadh;
-    } else if(strcmp(str, "Asia/Seoul") == 0) {
-        return Nuki::TimeZoneId::Asia_Seoul;
-    } else if(strcmp(str, "Asia/Shanghai") == 0) {
-        return Nuki::TimeZoneId::Asia_Shanghai;
-    } else if(strcmp(str, "Asia/Tehran") == 0) {
-        return Nuki::TimeZoneId::Asia_Tehran;
-    } else if(strcmp(str, "Asia/Tokyo") == 0) {
-        return Nuki::TimeZoneId::Asia_Tokyo;
-    } else if(strcmp(str, "Asia/Yangon") == 0) {
-        return Nuki::TimeZoneId::Asia_Yangon;
-    } else if(strcmp(str, "Australia/Adelaide") == 0) {
-        return Nuki::TimeZoneId::Australia_Adelaide;
-    } else if(strcmp(str, "Australia/Brisbane") == 0) {
-        return Nuki::TimeZoneId::Australia_Brisbane;
-    } else if(strcmp(str, "Australia/Darwin") == 0) {
-        return Nuki::TimeZoneId::Australia_Darwin;
-    } else if(strcmp(str, "Australia/Hobart") == 0) {
-        return Nuki::TimeZoneId::Australia_Hobart;
-    } else if(strcmp(str, "Australia/Perth") == 0) {
-        return Nuki::TimeZoneId::Australia_Perth;
-    } else if(strcmp(str, "Australia/Sydney") == 0) {
-        return Nuki::TimeZoneId::Australia_Sydney;
-    } else if(strcmp(str, "Europe/Berlin") == 0) {
-        return Nuki::TimeZoneId::Europe_Berlin;
-    } else if(strcmp(str, "Europe/Helsinki") == 0) {
-        return Nuki::TimeZoneId::Europe_Helsinki;
-    } else if(strcmp(str, "Europe/Istanbul") == 0) {
-        return Nuki::TimeZoneId::Europe_Istanbul;
-    } else if(strcmp(str, "Europe/London") == 0) {
-        return Nuki::TimeZoneId::Europe_London;
-    } else if(strcmp(str, "Europe/Moscow") == 0) {
-        return Nuki::TimeZoneId::Europe_Moscow;
-    } else if(strcmp(str, "Pacific/Auckland") == 0) {
-        return Nuki::TimeZoneId::Pacific_Auckland;
-    } else if(strcmp(str, "Pacific/Guam") == 0) {
-        return Nuki::TimeZoneId::Pacific_Guam;
-    } else if(strcmp(str, "Pacific/Honolulu") == 0) {
-        return Nuki::TimeZoneId::Pacific_Honolulu;
-    } else if(strcmp(str, "Pacific/Pago_Pago") == 0) {
-        return Nuki::TimeZoneId::Pacific_Pago_Pago;
-    } else if(strcmp(str, "None") == 0) {
-        return Nuki::TimeZoneId::None;
-    }
-    return (Nuki::TimeZoneId)0xff;
-}
-
-void NukiLockComponent::timezone_to_string(const Nuki::TimeZoneId timeZoneId, char* str) {
-    switch (timeZoneId) {
-        case Nuki::TimeZoneId::Africa_Cairo:
-            strcpy(str, "Africa/Cairo");
-            break;
-        case Nuki::TimeZoneId::Africa_Lagos:
-            strcpy(str, "Africa/Lagos");
-            break;
-        case Nuki::TimeZoneId::Africa_Maputo:
-            strcpy(str, "Africa/Maputo");
-            break;
-        case Nuki::TimeZoneId::Africa_Nairobi:
-            strcpy(str, "Africa/Nairobi");
-            break;
-        case Nuki::TimeZoneId::America_Anchorage:
-            strcpy(str, "America/Anchorage");
-            break;
-        case Nuki::TimeZoneId::America_Argentina_Buenos_Aires:
-            strcpy(str, "America/Argentina/Buenos_Aires");
-            break;
-        case Nuki::TimeZoneId::America_Chicago:
-            strcpy(str, "America/Chicago");
-            break;
-        case Nuki::TimeZoneId::America_Denver:
-            strcpy(str, "America/Denver");
-            break;
-        case Nuki::TimeZoneId::America_Halifax:
-            strcpy(str, "America/Halifax");
-            break;
-        case Nuki::TimeZoneId::America_Los_Angeles:
-            strcpy(str, "America/Los_Angeles");
-            break;
-        case Nuki::TimeZoneId::America_Manaus:
-            strcpy(str, "America/Manaus");
-            break;
-        case Nuki::TimeZoneId::America_Mexico_City:
-            strcpy(str, "America/Mexico_City");
-            break;
-        case Nuki::TimeZoneId::America_New_York:
-            strcpy(str, "America/New_York");
-            break;
-        case Nuki::TimeZoneId::America_Phoenix:
-            strcpy(str, "America/Phoenix");
-            break;
-        case Nuki::TimeZoneId::America_Regina:
-            strcpy(str, "America/Regina");
-            break;
-        case Nuki::TimeZoneId::America_Santiago:
-            strcpy(str, "America/Santiago");
-            break;
-        case Nuki::TimeZoneId::America_Sao_Paulo:
-            strcpy(str, "America/Sao_Paulo");
-            break;
-        case Nuki::TimeZoneId::America_St_Johns:
-            strcpy(str, "America/St_Johns");
-            break;
-        case Nuki::TimeZoneId::Asia_Bangkok:
-            strcpy(str, "Asia/Bangkok");
-            break;
-        case Nuki::TimeZoneId::Asia_Dubai:
-            strcpy(str, "Asia/Dubai");
-            break;
-        case Nuki::TimeZoneId::Asia_Hong_Kong:
-            strcpy(str, "Asia/Hong_Kong");
-            break;
-        case Nuki::TimeZoneId::Asia_Jerusalem:
-            strcpy(str, "Asia/Jerusalem");
-            break;
-        case Nuki::TimeZoneId::Asia_Karachi:
-            strcpy(str, "Asia/Karachi");
-            break;
-        case Nuki::TimeZoneId::Asia_Kathmandu:
-            strcpy(str, "Asia/Kathmandu");
-            break;
-        case Nuki::TimeZoneId::Asia_Kolkata:
-            strcpy(str, "Asia/Kolkata");
-            break;
-        case Nuki::TimeZoneId::Asia_Riyadh:
-            strcpy(str, "Asia/Riyadh");
-            break;
-        case Nuki::TimeZoneId::Asia_Seoul:
-            strcpy(str, "Asia/Seoul");
-            break;
-        case Nuki::TimeZoneId::Asia_Shanghai:
-            strcpy(str, "Asia/Shanghai");
-            break;
-        case Nuki::TimeZoneId::Asia_Tehran:
-            strcpy(str, "Asia/Tehran");
-            break;
-        case Nuki::TimeZoneId::Asia_Tokyo:
-            strcpy(str, "Asia/Tokyo");
-            break;
-        case Nuki::TimeZoneId::Asia_Yangon:
-            strcpy(str, "Asia/Yangon");
-            break;
-        case Nuki::TimeZoneId::Australia_Adelaide:
-            strcpy(str, "Australia/Adelaide");
-            break;
-        case Nuki::TimeZoneId::Australia_Brisbane:
-            strcpy(str, "Australia/Brisbane");
-            break;
-        case Nuki::TimeZoneId::Australia_Darwin:
-            strcpy(str, "Australia/Darwin");
-            break;
-        case Nuki::TimeZoneId::Australia_Hobart:
-            strcpy(str, "Australia/Hobart");
-            break;
-        case Nuki::TimeZoneId::Australia_Perth:
-            strcpy(str, "Australia/Perth");
-            break;
-        case Nuki::TimeZoneId::Australia_Sydney:
-            strcpy(str, "Australia/Sydney");
-            break;
-        case Nuki::TimeZoneId::Europe_Berlin:
-            strcpy(str, "Europe/Berlin");
-            break;
-        case Nuki::TimeZoneId::Europe_Helsinki:
-            strcpy(str, "Europe/Helsinki");
-            break;
-        case Nuki::TimeZoneId::Europe_Istanbul:
-            strcpy(str, "Europe/Istanbul");
-            break;
-        case Nuki::TimeZoneId::Europe_London:
-            strcpy(str, "Europe/London");
-            break;
-        case Nuki::TimeZoneId::Europe_Moscow:
-            strcpy(str, "Europe/Moscow");
-            break;
-        case Nuki::TimeZoneId::Pacific_Auckland:
-            strcpy(str, "Pacific/Auckland");
-            break;
-        case Nuki::TimeZoneId::Pacific_Guam:
-            strcpy(str, "Pacific/Guam");
-            break;
-        case Nuki::TimeZoneId::Pacific_Honolulu:
-            strcpy(str, "Pacific/Honolulu");
-            break;
-        case Nuki::TimeZoneId::Pacific_Pago_Pago:
-            strcpy(str, "Pacific/Pago_Pago");
-            break;
-        case Nuki::TimeZoneId::None:
-            strcpy(str, "None");
-            break;
-        default:
-            strcpy(str, "None");
-            break;
-    }
-}
-
-Nuki::AdvertisingMode NukiLockComponent::advertising_mode_to_enum(const char *str) {
-    if(strcmp(str, "Automatic") == 0) {
-        return Nuki::AdvertisingMode::Automatic;
-    } else if(strcmp(str, "Normal") == 0) {
-        return Nuki::AdvertisingMode::Normal;
-    } else if(strcmp(str, "Slow") == 0) {
-        return Nuki::AdvertisingMode::Slow;
-    } else if(strcmp(str, "Slowest") == 0) {
-        return Nuki::AdvertisingMode::Slowest;
-    }
-    return (Nuki::AdvertisingMode)0xff;
-}
-
-void NukiLockComponent::advertising_mode_to_string(const Nuki::AdvertisingMode mode, char* str) {
-    switch (mode) {
-        case Nuki::AdvertisingMode::Automatic:
-            strcpy(str, "Automatic");
-            break;
-        case Nuki::AdvertisingMode::Normal:
-            strcpy(str, "Normal");
-            break;
-        case Nuki::AdvertisingMode::Slow:
-            strcpy(str, "Slow");
-            break;
-        case Nuki::AdvertisingMode::Slowest:
-            strcpy(str, "Slowest");
-            break;
-        default:
-            strcpy(str, "Normal");
-            break;
-    }
-}
-
-void NukiLockComponent::pin_state_to_string(const PinState value, char* str)
-{
-    switch(value)
-    {
-        case PinState::NotSet:
-            strcpy(str, "Not set");
-            break;
-        case PinState::Set:
-            strcpy(str, "Validation pending");
-            break;
-        case PinState::Valid:
-            strcpy(str, "Valid");
-            break;
-        case PinState::Invalid:
-            strcpy(str, "Invalid");
-            break;
-        default:
-            strcpy(str, "Unknown");
-            break;
-    }
-}
-
 
 void NukiLockComponent::save_settings() {
     NukiLockSettings settings {
@@ -551,7 +58,7 @@ void NukiLockComponent::update_status() {
             this->retrieved_key_turner_state_.currentTimeSecond
         );
 
-        this->publish_state(this->nuki_to_lock_state(this->retrieved_key_turner_state_.lockState));
+        this->publish_state(nuki_lock::nuki_to_lock_state(this->retrieved_key_turner_state_.lockState));
 
         #ifdef USE_BINARY_SENSOR
         if (this->connected_binary_sensor_ != nullptr) {
@@ -570,7 +77,7 @@ void NukiLockComponent::update_status() {
         if (this->door_sensor_binary_sensor_ != nullptr) {
             Nuki::DoorSensorState door_sensor_state = this->retrieved_key_turner_state_.doorSensorState;
             if(door_sensor_state != Nuki::DoorSensorState::Unavailable) {
-                this->door_sensor_binary_sensor_->publish_state(this->nuki_doorsensor_to_binary(door_sensor_state));
+                this->door_sensor_binary_sensor_->publish_state(nuki_lock::nuki_doorsensor_to_binary(door_sensor_state));
             } else {
                 this->door_sensor_binary_sensor_->invalidate_state();
             }
@@ -645,8 +152,7 @@ void NukiLockComponent::update_config() {
 
     char str[50] = {0};
 
-    NukiLock::Config config;
-    Nuki::CmdResult conf_req_result = this->nuki_lock_.requestConfig(&config);
+    Nuki::CmdResult conf_req_result = this->nuki_lock_.requestConfig(&this->nuki_lock_config_);
     NukiLock::cmdResultToString(conf_req_result, str);
 
     App.feed_wdt();
@@ -654,87 +160,87 @@ void NukiLockComponent::update_config() {
     if (conf_req_result == Nuki::CmdResult::Success) {
         ESP_LOGD(TAG, "requestConfig has resulted in %s (%d)", str, conf_req_result);
 
-        keypad_paired_ = config.hasKeypad || config.hasKeypadV2;
+        ESP_LOGD(TAG, "Device Type: %i", (this->nuki_lock_config_.deviceType == 255 ? 0 : this->nuki_lock_config_.deviceType));
+        ESP_LOGD(TAG, "Product Variant: %i", (this->nuki_lock_config_.productVariant == 255 ? 0 : this->nuki_lock_config_.productVariant));
+
+        ESP_LOGD(TAG, "Firmware: %i.%i.%i", this->nuki_lock_config_.firmwareVersion[0], this->nuki_lock_config_.firmwareVersion[1], this->nuki_lock_config_.firmwareVersion[2]);
+        ESP_LOGD(TAG, "Hardware: %i.%i", this->nuki_lock_config_.hardwareRevision[0], this->nuki_lock_config_.hardwareRevision[1]);
+
+        ESP_LOGD(TAG, "Has Wifi: %s", YESNO(this->nuki_lock_config_.capabilities == 255 ? 0 : this->nuki_lock_config_.capabilities & 1));
+        ESP_LOGD(TAG, "Has Thread: %s", YESNO(this->nuki_lock_config_.capabilities == 255 ? 0 : ((this->nuki_lock_config_.capabilities & 2) != 0 ? 1 : 0)));
+
+        ESP_LOGD(TAG, "Matter Status: %i", (this->nuki_lock_config_.matterStatus == 255 ? 0 : this->nuki_lock_config_.matterStatus));
+        memset(str, 0, sizeof(str));
+        nuki_lock::homekit_status_to_string(this->nuki_lock_config_.homeKitStatus, str);
+        ESP_LOGD(TAG, "Homekit Status: %s", str);
+
+        keypad_paired_ = this->nuki_lock_config_.hasKeypad || (this->nuki_lock_config_.hasKeypadV2 != 0 && this->nuki_lock_config_.hasKeypadV2 != 255);
 
         #ifdef USE_SWITCH
         if (this->pairing_enabled_switch_ != nullptr) {
-            this->pairing_enabled_switch_->publish_state(config.pairingEnabled);
+            this->pairing_enabled_switch_->publish_state(this->nuki_lock_config_.pairingEnabled);
         }
 
         if (this->auto_unlatch_enabled_switch_ != nullptr) {
-            this->auto_unlatch_enabled_switch_->publish_state(config.autoUnlatch);
+            this->auto_unlatch_enabled_switch_->publish_state(this->nuki_lock_config_.autoUnlatch);
         }
         
         if (this->button_enabled_switch_ != nullptr) {
-            this->button_enabled_switch_->publish_state(config.buttonEnabled);
+            this->button_enabled_switch_->publish_state(this->nuki_lock_config_.buttonEnabled);
         }
         
         if (this->led_enabled_switch_ != nullptr) {
-            this->led_enabled_switch_->publish_state(config.ledEnabled);
+            this->led_enabled_switch_->publish_state(this->nuki_lock_config_.ledEnabled);
         }
         
         if (this->single_lock_enabled_switch_ != nullptr) {
-            this->single_lock_enabled_switch_->publish_state(config.singleLock);
+            this->single_lock_enabled_switch_->publish_state(this->nuki_lock_config_.singleLock);
         }
         
         if (this->dst_mode_enabled_switch_ != nullptr) {
-            this->dst_mode_enabled_switch_->publish_state(config.dstMode);
+            this->dst_mode_enabled_switch_->publish_state(this->nuki_lock_config_.dstMode);
         }
         #endif
         #ifdef USE_NUMBER
         if (this->led_brightness_number_ != nullptr) {
-            this->led_brightness_number_->publish_state(config.ledBrightness);
+            this->led_brightness_number_->publish_state(this->nuki_lock_config_.ledBrightness);
         }
         
         if (this->timezone_offset_number_ != nullptr) {
-            this->timezone_offset_number_->publish_state(config.timeZoneOffset);
+            this->timezone_offset_number_->publish_state(this->nuki_lock_config_.timeZoneOffset);
         }
         #endif
         #ifdef USE_SELECT
         if (this->fob_action_1_select_ != nullptr) {
             memset(str, 0, sizeof(str));
-            this->fob_action_to_string(config.fobAction1, str);
+            nuki_lock::fob_action_to_string(this->nuki_lock_config_.fobAction1, str);
             this->fob_action_1_select_->publish_state(str);
         }
         
         if (this->fob_action_2_select_ != nullptr) {
             memset(str, 0, sizeof(str));
-            this->fob_action_to_string(config.fobAction2, str);
+            nuki_lock::fob_action_to_string(this->nuki_lock_config_.fobAction2, str);
             this->fob_action_2_select_->publish_state(str);
         }
         
         if (this->fob_action_3_select_ != nullptr) {
             memset(str, 0, sizeof(str));
-            this->fob_action_to_string(config.fobAction3, str);
+            nuki_lock::fob_action_to_string(this->nuki_lock_config_.fobAction3, str);
             this->fob_action_3_select_->publish_state(str);
         }
         
         if (this->timezone_select_ != nullptr) {
             memset(str, 0, sizeof(str));
-            this->timezone_to_string(config.timeZoneId, str);
+            nuki_lock::timezone_to_string(this->nuki_lock_config_.timeZoneId, str);
             this->timezone_select_->publish_state(str);
         }
         
         if (this->advertising_mode_select_ != nullptr) {
             memset(str, 0, sizeof(str));
-            this->advertising_mode_to_string(config.advertisingMode, str);
+            nuki_lock::advertising_mode_to_string(this->nuki_lock_config_.advertisingMode, str);
             this->advertising_mode_select_->publish_state(str);
         }
         #endif
-        
-        ESP_LOGD(TAG, "Device Type: %i", (config.deviceType == 255 ? 0 : config.deviceType));
-        ESP_LOGD(TAG, "Product Variant: %i", (config.productVariant == 255 ? 0 : config.productVariant));
-
-        ESP_LOGD(TAG, "Firmware: %i.%i.%i", config.firmwareVersion[0], config.firmwareVersion[1], config.firmwareVersion[2]);
-        ESP_LOGD(TAG, "Hardware: %i.%i", config.hardwareRevision[0], config.hardwareRevision[1]);
-
-        ESP_LOGD(TAG, "Has Wifi: %s", YESNO(config.capabilities == 255 ? 0 : config.capabilities & 1));
-        ESP_LOGD(TAG, "Has Thread: %s", YESNO(config.capabilities == 255 ? 0 : ((config.capabilities & 2) != 0 ? 1 : 0)));
-
-        ESP_LOGD(TAG, "Matter Status: %i", (config.matterStatus == 255 ? 0 : config.matterStatus));
-        memset(str, 0, sizeof(str));
-        this->homekit_status_to_string(config.homeKitStatus, str);
-        ESP_LOGD(TAG, "Homekit Status: %s", str);
     } else {
         ESP_LOGE(TAG, "requestConfig has resulted in %s (%d)", str, conf_req_result);
         this->config_update_ = true;
@@ -746,8 +252,7 @@ void NukiLockComponent::update_advanced_config() {
 
     char str[50] = {0};
 
-    NukiLock::AdvancedConfig advanced_config;
-    Nuki::CmdResult conf_req_result = this->nuki_lock_.requestAdvancedConfig(&advanced_config);
+    Nuki::CmdResult conf_req_result = this->nuki_lock_.requestAdvancedConfig(&this->nuki_lock_advanced_config_);
     NukiLock::cmdResultToString(conf_req_result, str);
 
     App.feed_wdt();
@@ -757,100 +262,100 @@ void NukiLockComponent::update_advanced_config() {
 
         #ifdef USE_SWITCH
         if (this->nightmode_enabled_switch_ != nullptr) {
-            this->nightmode_enabled_switch_->publish_state(advanced_config.nightModeEnabled);
+            this->nightmode_enabled_switch_->publish_state(this->nuki_lock_advanced_config_.nightModeEnabled);
         }
 
         if (this->night_mode_auto_lock_enabled_switch_ != nullptr) {
-            this->night_mode_auto_lock_enabled_switch_->publish_state(advanced_config.nightModeAutoLockEnabled);
+            this->night_mode_auto_lock_enabled_switch_->publish_state(this->nuki_lock_advanced_config_.nightModeAutoLockEnabled);
         }
 
         if (this->night_mode_auto_unlock_disabled_switch_ != nullptr) {
-            this->night_mode_auto_unlock_disabled_switch_->publish_state(advanced_config.nightModeAutoUnlockDisabled);
+            this->night_mode_auto_unlock_disabled_switch_->publish_state(this->nuki_lock_advanced_config_.nightModeAutoUnlockDisabled);
         }
 
         if (this->night_mode_immediate_lock_on_start_switch_ != nullptr) {
-            this->night_mode_immediate_lock_on_start_switch_->publish_state(advanced_config.nightModeImmediateLockOnStart);
+            this->night_mode_immediate_lock_on_start_switch_->publish_state(this->nuki_lock_advanced_config_.nightModeImmediateLockOnStart);
         }
 
         if (this->auto_lock_enabled_switch_ != nullptr) {
-            this->auto_lock_enabled_switch_->publish_state(advanced_config.autoLockEnabled);
+            this->auto_lock_enabled_switch_->publish_state(this->nuki_lock_advanced_config_.autoLockEnabled);
         }
 
         if (this->auto_unlock_disabled_switch_ != nullptr) {
-            this->auto_unlock_disabled_switch_->publish_state(advanced_config.autoUnLockDisabled);
+            this->auto_unlock_disabled_switch_->publish_state(this->nuki_lock_advanced_config_.autoUnLockDisabled);
         }
 
         if (this->immediate_auto_lock_enabled_switch_ != nullptr) {
-            this->immediate_auto_lock_enabled_switch_->publish_state(advanced_config.immediateAutoLockEnabled);
+            this->immediate_auto_lock_enabled_switch_->publish_state(this->nuki_lock_advanced_config_.immediateAutoLockEnabled);
         }
 
         if (this->auto_update_enabled_switch_ != nullptr) {
-            this->auto_update_enabled_switch_->publish_state(advanced_config.autoUpdateEnabled);
+            this->auto_update_enabled_switch_->publish_state(this->nuki_lock_advanced_config_.autoUpdateEnabled);
         }
 
         // Gen 1-4 only
         if (!this->nuki_lock_.isLockUltra() && this->auto_battery_type_detection_enabled_switch_ != nullptr) {
-            this->auto_battery_type_detection_enabled_switch_->publish_state(advanced_config.automaticBatteryTypeDetection);
+            this->auto_battery_type_detection_enabled_switch_->publish_state(this->nuki_lock_advanced_config_.automaticBatteryTypeDetection);
         }
 
         // Ultra only
         if (this->nuki_lock_.isLockUltra() && this->slow_speed_during_night_mode_enabled_switch_ != nullptr) {
-            this->slow_speed_during_night_mode_enabled_switch_->publish_state(advanced_config.enableSlowSpeedDuringNightMode);
+            this->slow_speed_during_night_mode_enabled_switch_->publish_state(this->nuki_lock_advanced_config_.enableSlowSpeedDuringNightMode);
         }
 
         if (this->detached_cylinder_enabled_switch_ != nullptr) {
-            this->detached_cylinder_enabled_switch_->publish_state(advanced_config.detachedCylinder);
+            this->detached_cylinder_enabled_switch_->publish_state(this->nuki_lock_advanced_config_.detachedCylinder);
         }
         #endif
 
         #ifdef USE_NUMBER
         if (this->lock_n_go_timeout_number_ != nullptr) {
-            this->lock_n_go_timeout_number_->publish_state(advanced_config.lockNgoTimeout);
+            this->lock_n_go_timeout_number_->publish_state(this->nuki_lock_advanced_config_.lockNgoTimeout);
         }
         if (this->auto_lock_timeout_number_ != nullptr) {
-            this->auto_lock_timeout_number_->publish_state(advanced_config.autoLockTimeOut);
+            this->auto_lock_timeout_number_->publish_state(this->nuki_lock_advanced_config_.autoLockTimeOut);
         }
         if (this->unlatch_duration_number_ != nullptr) {
-            this->unlatch_duration_number_->publish_state(advanced_config.unlatchDuration);
+            this->unlatch_duration_number_->publish_state(this->nuki_lock_advanced_config_.unlatchDuration);
         }
         if (this->unlocked_position_offset_number_ != nullptr) {
-            this->unlocked_position_offset_number_->publish_state(advanced_config.unlockedPositionOffsetDegrees);
+            this->unlocked_position_offset_number_->publish_state(this->nuki_lock_advanced_config_.unlockedPositionOffsetDegrees);
         }
         if (this->locked_position_offset_number_ != nullptr) {
-            this->locked_position_offset_number_->publish_state(advanced_config.lockedPositionOffsetDegrees);
+            this->locked_position_offset_number_->publish_state(this->nuki_lock_advanced_config_.lockedPositionOffsetDegrees);
         }
         if (this->single_locked_position_offset_number_ != nullptr) {
-            this->single_locked_position_offset_number_->publish_state(advanced_config.singleLockedPositionOffsetDegrees);
+            this->single_locked_position_offset_number_->publish_state(this->nuki_lock_advanced_config_.singleLockedPositionOffsetDegrees);
         }
         if (this->unlocked_to_locked_transition_offset_number_ != nullptr) {
-            this->unlocked_to_locked_transition_offset_number_->publish_state(advanced_config.unlockedToLockedTransitionOffsetDegrees);
+            this->unlocked_to_locked_transition_offset_number_->publish_state(this->nuki_lock_advanced_config_.unlockedToLockedTransitionOffsetDegrees);
         }
         #endif
 
         #ifdef USE_SELECT
         if (this->single_button_press_action_select_ != nullptr) {
             memset(str, 0, sizeof(str));
-            this->button_press_action_to_string(advanced_config.singleButtonPressAction, str);
+            nuki_lock::button_press_action_to_string(this->nuki_lock_advanced_config_.singleButtonPressAction, str);
             this->single_button_press_action_select_->publish_state(str);
         }
 
         if (this->double_button_press_action_select_ != nullptr) {
             memset(str, 0, sizeof(str));
-            this->button_press_action_to_string(advanced_config.doubleButtonPressAction, str);
+            nuki_lock::button_press_action_to_string(this->nuki_lock_advanced_config_.doubleButtonPressAction, str);
             this->double_button_press_action_select_->publish_state(str);
         }
 
         // Gen 1-4 only
         if (!this->nuki_lock_.isLockUltra() && this->battery_type_select_ != nullptr) {
             memset(str, 0, sizeof(str));
-            this->battery_type_to_string(advanced_config.batteryType, str);
+            nuki_lock::battery_type_to_string(this->nuki_lock_advanced_config_.batteryType, str);
             this->battery_type_select_->publish_state(str);
         }
 
         // Ultra
         if (this->nuki_lock_.isLockUltra() && this->motor_speed_select_ != nullptr) {
             memset(str, 0, sizeof(str));
-            this->motor_speed_to_string(advanced_config.motorSpeed, str);
+            nuki_lock::motor_speed_to_string(this->nuki_lock_advanced_config_.motorSpeed, str);
             this->motor_speed_select_->publish_state(str);
         }
         #endif
@@ -862,7 +367,6 @@ void NukiLockComponent::update_advanced_config() {
 
 void NukiLockComponent::update_auth_data() {
     this->auth_data_update_ = false;
-    this->cancel_timeout("wait_for_auth_data");
 
     if(this->pin_state_ != PinState::Valid) {
         ESP_LOGW(TAG, "It seems like you did not set a valid pin!");
@@ -877,51 +381,56 @@ void NukiLockComponent::update_auth_data() {
 
     if (auth_data_req_result == Nuki::CmdResult::Success) {
         ESP_LOGD(TAG, "retrieveAuthorizationEntries has resulted in %s (%d)", auth_data_req_result_as_string, auth_data_req_result);
-
-        this->set_timeout("wait_for_auth_data", 5000, [this]() {
-
-            std::list<NukiLock::AuthorizationEntry> authEntries;
-            this->nuki_lock_.getAuthorizationEntries(&authEntries);
-    
-            if (!authEntries.empty()) {
-                ESP_LOGD(TAG, "Authorization Entry Count: %d", authEntries.size());
-
-                authEntries.sort([](const NukiLock::AuthorizationEntry& a, const NukiLock::AuthorizationEntry& b) {
-                    return a.authId < b.authId;
-                });
-        
-                if (authEntries.size() > MAX_AUTH_DATA_ENTRIES) {
-                    authEntries.resize(MAX_AUTH_DATA_ENTRIES);
-                }
-
-                this->auth_entries_count_ = 0;
-
-                for(const auto& entry : authEntries) {
-                    if (this->auth_entries_count_ >= MAX_AUTH_DATA_ENTRIES) break;
-
-                    AuthEntry& auth_entry = this->auth_entries_[this->auth_entries_count_];
-                    auth_entry.authId = entry.authId;
-
-                    strncpy(auth_entry.name, reinterpret_cast<const char*>(entry.name), MAX_NAME_LEN - 1);
-                    auth_entry.name[MAX_NAME_LEN - 1] = '\0';
-
-                    ESP_LOGD(TAG, "Authorization entry[%d] type: %d name: %s", entry.authId, entry.idType, entry.name);
-
-                    this->auth_entries_count_++;
-                }
-            } else {
-                ESP_LOGW(TAG, "No auth entries!");
-            }
-        });
+        this->auth_data_ready_time_ = millis() + 5000;
     } else {
         ESP_LOGE(TAG, "retrieveAuthorizationEntries has resulted in %s (%d)", auth_data_req_result_as_string, auth_data_req_result);
         this->auth_data_update_ = true;
     }
 }
 
+void NukiLockComponent::process_auth_data() {
+    ESP_LOGD(TAG, "Process Authorization Entries");
+
+    std::list<NukiLock::AuthorizationEntry> authEntries;
+    this->nuki_lock_.getAuthorizationEntries(&authEntries);
+
+    App.feed_wdt();
+
+    if (authEntries.empty()) {
+        ESP_LOGW(TAG, "No auth entries!");
+        return;
+    }
+
+    ESP_LOGD(TAG, "Authorization Entry Count: %d", authEntries.size());
+
+    authEntries.sort([](const NukiLock::AuthorizationEntry& a, const NukiLock::AuthorizationEntry& b) {
+        return a.authId < b.authId;
+    });
+
+    if (authEntries.size() > MAX_AUTH_DATA_ENTRIES) {
+        authEntries.resize(MAX_AUTH_DATA_ENTRIES);
+        ESP_LOGW(TAG, "Authorization entry count exceeds maximum, resized to maximum!");
+    }
+
+    this->auth_entries_count_ = 0;
+
+    for(const auto& entry : authEntries) {
+        if (this->auth_entries_count_ >= MAX_AUTH_DATA_ENTRIES) break;
+
+        AuthEntry& auth_entry = this->auth_entries_[this->auth_entries_count_];
+        auth_entry.authId = entry.authId;
+
+        strncpy(auth_entry.name, reinterpret_cast<const char*>(entry.name), MAX_NAME_LEN - 1);
+        auth_entry.name[MAX_NAME_LEN - 1] = '\0';
+
+        ESP_LOGD(TAG, "Authorization entry[%d] type: %d name: %s", entry.authId, entry.idType, entry.name);
+
+        this->auth_entries_count_++;
+    }
+}
+
 void NukiLockComponent::update_event_logs() {
     this->event_log_update_ = false;
-    this->cancel_timeout("wait_for_log_entries");
 
     if(this->pin_state_ != PinState::Valid) {
         ESP_LOGW(TAG, "It seems like you did not set a valid pin!");
@@ -936,37 +445,36 @@ void NukiLockComponent::update_event_logs() {
 
     if (event_log_req_result == Nuki::CmdResult::Success) {
         ESP_LOGD(TAG, "retrieveLogEntries has resulted in %s (%d)", event_log_req_result_as_string, event_log_req_result);
-
-        this->set_timeout("wait_for_log_entries", 5000, [this]() {
-            std::list<NukiLock::LogEntry> log;
-            this->nuki_lock_.getLogEntries(&log);
-
-            App.feed_wdt();
-
-            if (!log.empty()) {
-                ESP_LOGD(TAG, "Log Entry Count: %d", log.size());
-
-                if (log.size() > MAX_EVENT_LOG_ENTRIES) {
-                    log.resize(MAX_EVENT_LOG_ENTRIES);
-                }
-        
-                log.sort([](const NukiLock::LogEntry& a, const NukiLock::LogEntry& b) {
-                    return a.index < b.index;
-                });
-
-                this->process_log_entries(log);
-            } else {
-                ESP_LOGW(TAG, "No log entries!");
-            }
-        });
+        this->event_log_ready_time_ = millis() + 5000;
     } else {
         ESP_LOGE(TAG, "retrieveLogEntries has resulted in %s (%d)", event_log_req_result_as_string, event_log_req_result);
         this->event_log_update_ = true;
     }
 }
 
-void NukiLockComponent::process_log_entries(const std::list<NukiLock::LogEntry>& log_entries) {
+void NukiLockComponent::process_log_entries() {
     ESP_LOGD(TAG, "Process Event Log Entries");
+
+    std::list<NukiLock::LogEntry> log_entries;
+    this->nuki_lock_.getLogEntries(&log_entries);
+
+    App.feed_wdt();
+
+    if (log_entries.empty()) {
+        ESP_LOGW(TAG, "No log entries!");
+        return;
+    }
+
+    ESP_LOGD(TAG, "Log Entry Count: %d", log_entries.size());
+
+    if (log_entries.size() > MAX_EVENT_LOG_ENTRIES) {
+        log_entries.resize(MAX_EVENT_LOG_ENTRIES);
+        ESP_LOGW(TAG, "Log entry count exceeds maximum, resized to maximum!");
+    }
+
+    log_entries.sort([](const NukiLock::LogEntry& a, const NukiLock::LogEntry& b) {
+        return a.index < b.index;
+    });
 
     char buffer[50] = {0};
     char num_buffer[16];
@@ -1171,23 +679,21 @@ void NukiLockComponent::set_security_pin(uint32_t new_pin) {
         return;
     }
 
-    // Mark as set but needs validation
-    this->pin_state_ = PinState::Set;
-    this->save_settings();
-    this->publish_pin_state();
-
     // Save pin
     const bool result = this->nuki_lock_.isLockUltra() ? this->nuki_lock_.saveUltraPincode(pin_to_use) : this->nuki_lock_.saveSecurityPincode(static_cast<uint16_t>(pin_to_use));
 
-    if (result) {
-        ESP_LOGI(TAG, "Successfully saved security pin");
-    } else {
+    if (!result) {
         ESP_LOGE(TAG, "Failed to save security pin");
         this->pin_state_ = PinState::Invalid;
         this->save_settings();
         this->publish_pin_state();
         return;
     }
+
+    ESP_LOGI(TAG, "Successfully saved security pin");
+    this->pin_state_ = PinState::Set;
+    this->save_settings();
+    this->publish_pin_state();
 
     // Validate pin if lock is paired and connected
     if (this->nuki_lock_.isPairedWithLock() && this->connected_) {
@@ -1202,52 +708,24 @@ void NukiLockComponent::validate_pin()
 {
     ESP_LOGD(TAG, "Check if pin is valid and save state");
 
-    cancel_retry("validate_pin");
-
     if(this->pin_state_ == PinState::NotSet) {
         ESP_LOGD(TAG, "Pin is not set, no validation needed!");
         return;
     }
 
-    this->set_retry(
-        "validate_pin", 100, 4,
-        [this](const uint8_t remaining_attempts) {
-
-            ESP_LOGD(TAG, "verifySecurityPin attempts left: %d", remaining_attempts);
-
-            Nuki::CmdResult pin_result = this->nuki_lock_.verifySecurityPin();
-
-            App.feed_wdt();
-
-            if(pin_result == Nuki::CmdResult::Success) {
-                ESP_LOGI(TAG, "Nuki Lock PIN is valid");
-
-                if(this->pin_state_ != PinState::Valid) {
-                    this->pin_state_ = PinState::Valid;
-                    this->save_settings();
-                    this->publish_pin_state();
-                }
-                return RetryResult::DONE;
-
-            } else if (remaining_attempts == 0) {
-                ESP_LOGD(TAG, "Nuki Lock PIN is invalid or not set");
-
-                if(this->pin_state_ != PinState::Invalid) {
-                    this->pin_state_ = PinState::Invalid;
-                    this->save_settings();
-                    this->publish_pin_state();
-                }
-            }
-            ESP_LOGW(TAG, "verifySecurityPin: result %d, retry...", pin_result);
-            return RetryResult::RETRY;
-        },
-        1.0f
-    );
+    this->pin_validation_pending_ = true;
 }
 
-void NukiLockComponent::setup() {
-    ESP_LOGCONFIG(TAG, "Running setup");
+void NukiLockComponent::nuki_task_fn(void *arg)
+{
+    esp_task_wdt_add(NULL);
 
+    auto *lock_component = static_cast<NukiLockComponent *>(arg);
+    lock_component->nuki_task_loop();
+}
+
+void NukiLockComponent::nuki_task_loop()
+{
     // Increase Watchdog Timeout
     // Fixes Pairing Crash
     esp_task_wdt_config_t wdt_config = {
@@ -1255,6 +733,191 @@ void NukiLockComponent::setup() {
         .trigger_panic = false
     }; 
     esp_task_wdt_reconfigure(&wdt_config);
+
+    uint32_t last_loop_time = millis();
+
+    while(true)
+    {
+        // Only execute main logic every 500ms
+        uint32_t current_time = millis();
+        if (current_time - last_loop_time < 500) {
+            delay(10);  // Small delay to prevent tight loop
+            continue;
+        }
+        last_loop_time = current_time;
+
+        // Check for new advertisements
+        this->scanner_.update();
+        App.feed_wdt();
+        delay(20);
+
+        // Terminate stale Bluetooth connections
+        this->nuki_lock_.updateConnectionState();
+
+        App.feed_wdt();
+
+        if (millis() - last_command_executed_time_ < command_cooldown_millis) {
+            // Give the lock time to terminate the previous command
+            uint64_t millisSinceLastExecution = millis() - last_command_executed_time_;
+            uint64_t millisLeft = (millisSinceLastExecution < command_cooldown_millis) ? command_cooldown_millis - millisSinceLastExecution : 1;
+            ESP_LOGV(TAG, "Cooldown period, %dms left", millisLeft);
+            continue;
+        }
+
+        if (this->nuki_lock_.isPairedWithLock()) {
+            // Validate PIN in task without blocking
+            if (this->pin_validation_pending_) {
+                if (this->pin_validation_attempts_ == 0) {
+                    // First attempt, start timer
+                    this->pin_validation_start_time_ = millis();
+                    this->pin_validation_attempts_ = 4;
+                }
+
+                // Check if enough time has passed since last attempt (100ms)
+                if (millis() - this->pin_validation_start_time_ >= 100) {
+                    this->pin_validation_start_time_ = millis();
+                    this->pin_validation_attempts_--;
+                    
+                    ESP_LOGD(TAG, "verifySecurityPin attempts left: %d", this->pin_validation_attempts_);
+                    
+                    App.feed_wdt();
+                    Nuki::CmdResult pin_result = this->nuki_lock_.verifySecurityPin();
+                    App.feed_wdt();
+                    
+                    if(pin_result == Nuki::CmdResult::Success) {
+                        ESP_LOGI(TAG, "Nuki Lock PIN is valid");
+                        this->pin_state_ = PinState::Valid;
+                        this->pin_validation_pending_ = false;
+                        this->save_settings();
+                        this->publish_pin_state();
+                    } else if (this->pin_validation_attempts_ == 0) {
+                        ESP_LOGD(TAG, "Nuki Lock PIN is invalid or not set");
+                        this->pin_state_ = PinState::Invalid;
+                        this->pin_validation_pending_ = false;
+                        this->save_settings();
+                        this->publish_pin_state();
+                    } else {
+                        ESP_LOGW(TAG, "verifySecurityPin: result %d, retry...", pin_result);
+                    }
+                }
+            }
+
+            // Execute (all) actions first, then status updates, then config updates.
+            // Only one command (action, status, config, or auth data) is executed per update() call.
+            if (this->action_attempts_ > 0) {
+                this->action_attempts_--;
+
+                NukiLock::LockAction currentLockAction = this->lock_action_;
+                char currentlock_action_as_string[30] = {0};
+                NukiLock::lockactionToString(currentLockAction, currentlock_action_as_string);
+
+                ESP_LOGD(TAG, "Executing lock action %s (%d)... (%d attempts left)", currentlock_action_as_string, currentLockAction, this->action_attempts_);
+
+                bool isExecutionSuccessful = this->execute_lock_action(currentLockAction);
+
+                App.feed_wdt();
+
+                if (isExecutionSuccessful) {
+                    if (this->lock_action_ == currentLockAction) {
+                        // Stop action attempts only if no new action was received in the meantime.
+                        // Otherwise, the new action won't be executed.
+                        this->action_attempts_ = 0;
+                    }
+                } else if (this->action_attempts_ == 0) {
+                    this->connected_ = false;
+                    
+                    // Publish failed state only when no attempts are left
+                    this->publish_state(lock::LOCK_STATE_NONE);
+
+                    #ifdef USE_BINARY_SENSOR
+                    if (this->connected_binary_sensor_ != nullptr)
+                    {
+                        this->connected_binary_sensor_->publish_state(this->connected_);
+                    }  
+                    #endif
+                }
+
+                // Schedule a status update without waiting for the next advertisement for a faster feedback
+                this->status_update_ = true;
+
+                // Give the lock extra time when successful in order to account for time to turn the key
+                command_cooldown_millis = isExecutionSuccessful ? COOLDOWN_COMMANDS_EXTENDED_MILLIS : COOLDOWN_COMMANDS_MILLIS;
+
+            } else if (this->status_update_) {
+                ESP_LOGD(TAG, "Requesting status...");
+                this->update_status();
+                command_cooldown_millis = COOLDOWN_COMMANDS_MILLIS;
+            } else if (this->config_update_) {
+                ESP_LOGD(TAG, "Requesting config...");
+                this->update_config();
+                command_cooldown_millis = COOLDOWN_COMMANDS_MILLIS;
+            } else if (this->auth_data_update_) {
+                ESP_LOGD(TAG, "Requesting auth data...");
+                this->update_auth_data();
+                command_cooldown_millis = COOLDOWN_COMMANDS_MILLIS;
+            } else if (this->event_log_update_) {
+                ESP_LOGD(TAG, "Requesting event logs...");
+                this->update_event_logs();
+                command_cooldown_millis = COOLDOWN_COMMANDS_MILLIS;
+            } else if (this->advanced_config_update_) {
+                ESP_LOGD(TAG, "Requesting advanced config...");
+                this->update_advanced_config();
+                command_cooldown_millis = COOLDOWN_COMMANDS_MILLIS;
+            }
+
+            // Process retrieved data
+            if (this->auth_data_ready_time_ > 0 && millis() >= this->auth_data_ready_time_) {
+                this->process_auth_data();
+                this->auth_data_ready_time_ = 0;
+            } else if (this->event_log_ready_time_ > 0 && millis() >= this->event_log_ready_time_) {
+                this->process_log_entries();
+                this->event_log_ready_time_ = 0;
+            }
+
+            last_command_executed_time_ = millis();
+
+        } else {
+            this->connected_ = false;
+
+            #ifdef USE_BINARY_SENSOR
+            if (this->paired_binary_sensor_ != nullptr) {
+                this->paired_binary_sensor_->publish_state(false);
+            }
+            if (this->connected_binary_sensor_ != nullptr) {
+                this->connected_binary_sensor_->publish_state(connected_);
+            }
+            #endif
+
+            // Pairing Mode is active
+            if (this->pairing_mode_) {
+                // Pair Nuki
+                Nuki::AuthorizationIdType type = this->pairing_as_app_.value_or(false) ? Nuki::AuthorizationIdType::App : Nuki::AuthorizationIdType::Bridge;
+                
+                App.feed_wdt();
+
+                bool paired = this->nuki_lock_.pairNuki(type) == Nuki::PairingResult::Success;
+
+                App.feed_wdt();
+
+                if (paired) {
+                    this->setup_lock(true);
+
+                    this->paired_callback_.call();
+                    this->set_pairing_mode(false);
+                }
+
+                #ifdef USE_BINARY_SENSOR
+                if (this->paired_binary_sensor_ != nullptr) {
+                    this->paired_binary_sensor_->publish_state(paired);
+                }
+                #endif
+            }
+        }
+    }
+}
+
+void NukiLockComponent::setup() {
+    ESP_LOGCONFIG(TAG, "Running setup");
 
     // Restore settings from flash
     this->pref_ = global_preferences->make_preference<NukiLockSettings>(global_nuki_lock_id);
@@ -1266,6 +929,8 @@ void NukiLockComponent::setup() {
 
     this->pin_state_ = recovered.pin_state;
     this->security_pin_ = recovered.security_pin;
+
+    this->traits.set_supports_open(true);
 
     this->traits.set_supported_states({
         lock::LOCK_STATE_NONE,
@@ -1300,7 +965,7 @@ void NukiLockComponent::setup() {
         pin_to_use = this->security_pin_config_.value_or(0);
     } else {
         this->pin_state_ = PinState::NotSet;
-        ESP_LOGW(TAG, "The security pin is not set. The security pin is crucial to pair a Smart Lock Ultra.");
+        ESP_LOGW(TAG, "The security pin is not set - it is crucial to pair a 5th Gen Smart Lock (Ultra / Go / Pro).");
     }
 
     if (pin_to_use != 0) {
@@ -1320,6 +985,7 @@ void NukiLockComponent::setup() {
     this->nuki_lock_.setDebugHexData(false);
     this->nuki_lock_.setDebugCommand(false);
 
+    this->nuki_lock_.setEventHandler(this);
     this->nuki_lock_.initialize();
     this->nuki_lock_.registerBleScanner(&this->scanner_);
     this->nuki_lock_.setConnectTimeout(BLE_CONNECT_TIMEOUT_SEC);
@@ -1330,44 +996,7 @@ void NukiLockComponent::setup() {
     
     App.feed_wdt();
 
-    if (this->nuki_lock_.isPairedWithLock()) {
-        this->status_update_ = true;
-
-        // First boot: Request config and auth data
-        this->config_update_ = true;
-        this->advanced_config_update_ = true;
-        if (this->send_events_) {
-            this->auth_data_update_ = true;
-            this->event_log_update_ = true;
-        }
-
-        const char* pairing_type = this->pairing_as_app_.value_or(false) ? "App" : "Bridge";
-        const char* lock_type = this->nuki_lock_.isLockUltra() ? "Ultra / Go / 5th Gen" : "1st - 4th Gen";
-        ESP_LOGI(TAG, "This component is already paired as %s with a %s smart lock!", pairing_type, lock_type);
-
-        #ifdef USE_BINARY_SENSOR
-        if (this->paired_binary_sensor_ != nullptr)
-        {
-            this->paired_binary_sensor_->publish_initial_state(true);
-        }
-        #endif
-
-        this->validate_pin();
-
-        this->setup_intervals();
-
-    } else {
-        ESP_LOGI(TAG, "This component is not paired yet. Enable the pairing mode to pair with your smart lock.");
-        #ifdef USE_BINARY_SENSOR
-        if (this->paired_binary_sensor_ != nullptr)
-        {
-            this->paired_binary_sensor_->publish_initial_state(false);
-        }     
-        #endif
-    }
-
     this->publish_pin_state();
-
     this->publish_state(lock::LOCK_STATE_NONE);
 
     #ifdef USE_API
@@ -1389,12 +1018,96 @@ void NukiLockComponent::setup() {
         ESP_LOGW(TAG, "More information here: https://esphome.io/components/api.html");
         #endif
     #endif
+
+    // Initial connection
+    if (this->nuki_lock_.isPairedWithLock()) {
+        this->setup_lock();
+
+        #ifdef USE_BINARY_SENSOR
+        if (this->paired_binary_sensor_ != nullptr)
+        {
+            this->paired_binary_sensor_->publish_state(true);
+        }
+        #endif
+    } else {
+        ESP_LOGI(TAG, "This component is not paired yet. Enable the pairing mode to pair with your smart lock.");
+
+        #ifdef USE_BINARY_SENSOR
+        if (this->paired_binary_sensor_ != nullptr)
+        {
+            this->paired_binary_sensor_->publish_state(false);
+        }
+        #endif
+    }
+
+    xTaskCreatePinnedToCore(nuki_task_fn, "nuki_task", 4096, (void *) this, 2, &this->nuki_task_handle_, 0);
+    if (this->nuki_task_handle_ == nullptr) {
+        ESP_LOGE(TAG, "Failed to create Nuki task");
+        this->mark_failed();
+        return;
+    }
+    ESP_LOGD(TAG, "Nuki Task created");
+}
+
+
+
+void NukiLockComponent::setup_lock(bool new_pairing) {
+    const char* pairing_type = this->pairing_as_app_.value_or(false) ? "App" : "Bridge";
+    const char* lock_type = this->nuki_lock_.isLockUltra() ? "5th Gen (Ultra / Go / Pro)" : "1st - 4th Gen";
+    ESP_LOGI(TAG, "This component is paired as %s with a %s smart lock!", pairing_type, lock_type);
+
+    const uint32_t pin_to_use = this->security_pin_ != 0 ? this->security_pin_ : this->security_pin_config_.value_or(0);
+
+    if(new_pairing) {
+        if (this->security_pin_ != 0) {
+            ESP_LOGW(TAG, "Using security pin override instead of YAML config");
+        }
+
+        if (pin_to_use == 0) {
+            ESP_LOGD(TAG, "No security pin configured, skipping pin setup");
+            this->pin_state_ = PinState::NotSet;
+        } else if (pin_to_use > 999999) {
+            ESP_LOGE(TAG, "Invalid security pin detected! Maximum is 6 digits (999999)");
+            this->pin_state_ = PinState::Invalid;
+        } else if (!this->nuki_lock_.isLockUltra() && pin_to_use > 65535) {
+            ESP_LOGE(TAG, "Security pin exceeds maximum of 65535 for 1st to 4th Gen Smart Locks", pin_to_use);
+            this->pin_state_ = PinState::Invalid;
+        } else {
+            const bool result = this->nuki_lock_.isLockUltra() ? this->nuki_lock_.saveUltraPincode(pin_to_use) : this->nuki_lock_.saveSecurityPincode(static_cast<uint16_t>(pin_to_use));
+
+            if (result) {
+                ESP_LOGI(TAG, "Successfully set security pin");
+                this->pin_state_ = PinState::Set;
+            } else {
+                ESP_LOGE(TAG, "Failed to set security pin");
+                this->pin_state_ = PinState::Invalid;
+            }
+        }
+
+        this->save_settings();
+        this->publish_pin_state();
+    }
+
+    if(pin_to_use != 0) {
+        this->validate_pin();
+    }
+
+    // Initialize Lock: Request config and auth data
+    this->status_update_ = true;
+    this->config_update_ = true;
+    this->advanced_config_update_ = true;
+    if (this->send_events_) {
+        this->auth_data_update_ = true;
+        this->event_log_update_ = true;
+    }
+
+    this->setup_intervals();
 }
 
 void NukiLockComponent::publish_pin_state() {
     #ifdef USE_TEXT_SENSOR
     char pin_state_as_string[20] = {0};
-    this->pin_state_to_string(this->pin_state_, pin_state_as_string);
+    nuki_lock::pin_state_to_string(this->pin_state_, pin_state_as_string);
 
     if (this->pin_state_text_sensor_ != nullptr && this->pin_state_text_sensor_->state != pin_state_as_string) {
         this->pin_state_text_sensor_->publish_state(pin_state_as_string);
@@ -1415,187 +1128,6 @@ void NukiLockComponent::setup_intervals(bool setup) {
         this->set_interval("update_auth_data", this->query_interval_auth_data_ * 1000, [this]() {
             this->auth_data_update_ = true;
         });
-    }
-}
-
-void NukiLockComponent::update() {
-    // Check for new advertisements
-    this->scanner_.update();
-    App.feed_wdt();
-    delay(20);
-
-    /*int64_t ts = millis();
-    int64_t last_received_beacon_ts = this->nuki_lock_.getLastReceivedBeaconTs();
-
-    if(ts > 60000 && last_received_beacon_ts > 0 && (ts - last_received_beacon_ts > 60 * 1000))
-    {
-        ESP_LOGW(TAG, "We received no BLE beacon for %d seconds!", (ts - last_received_beacon_ts) / 1000);
-    }*/
-
-    // Terminate stale Bluetooth connections
-    this->nuki_lock_.updateConnectionState();
-
-    App.feed_wdt();
-
-    if (millis() - last_command_executed_time_ < command_cooldown_millis) {
-        // Give the lock time to terminate the previous command
-        uint64_t millisSinceLastExecution = millis() - last_command_executed_time_;
-        uint64_t millisLeft = (millisSinceLastExecution < command_cooldown_millis) ? command_cooldown_millis - millisSinceLastExecution : 1;
-        ESP_LOGV(TAG, "Cooldown period, %dms left", millisLeft);
-        return;
-    }
-
-    if (this->nuki_lock_.isPairedWithLock()) {
-        #ifdef USE_BINARY_SENSOR
-        if (this->paired_binary_sensor_ != nullptr)
-        {
-            this->paired_binary_sensor_->publish_state(true);
-        } 
-        #endif
-
-        // Execute (all) actions first, then status updates, then config updates.
-        // Only one command (action, status, config, or auth data) is executed per update() call.
-        if (this->action_attempts_ > 0) {
-            this->action_attempts_--;
-
-            NukiLock::LockAction currentLockAction = this->lock_action_;
-            char currentlock_action_as_string[30] = {0};
-            NukiLock::lockactionToString(currentLockAction, currentlock_action_as_string);
-
-            ESP_LOGD(TAG, "Executing lock action %s (%d)... (%d attempts left)", currentlock_action_as_string, currentLockAction, this->action_attempts_);
-
-            bool isExecutionSuccessful = this->execute_lock_action(currentLockAction);
-
-            App.feed_wdt();
-
-            if (isExecutionSuccessful) {
-                if (this->lock_action_ == currentLockAction) {
-                    // Stop action attempts only if no new action was received in the meantime.
-                    // Otherwise, the new action won't be executed.
-                    this->action_attempts_ = 0;
-                }
-            } else if (this->action_attempts_ == 0) {
-                this->connected_ = false;
-                
-                // Publish failed state only when no attempts are left
-                this->publish_state(lock::LOCK_STATE_NONE);
-
-                #ifdef USE_BINARY_SENSOR
-                if (this->connected_binary_sensor_ != nullptr)
-                {
-                    this->connected_binary_sensor_->publish_state(this->connected_);
-                }  
-                #endif
-            }
-
-            // Schedule a status update without waiting for the next advertisement for a faster feedback
-            this->status_update_ = true;
-
-            // Give the lock extra time when successful in order to account for time to turn the key
-            command_cooldown_millis = isExecutionSuccessful ? COOLDOWN_COMMANDS_EXTENDED_MILLIS : COOLDOWN_COMMANDS_MILLIS;
-
-        } else if (this->status_update_) {
-            ESP_LOGD(TAG, "Requesting status...");
-            this->update_status();
-            command_cooldown_millis = COOLDOWN_COMMANDS_MILLIS;
-        } else if (this->config_update_) {
-            ESP_LOGD(TAG, "Requesting config...");
-            this->update_config();
-            command_cooldown_millis = COOLDOWN_COMMANDS_MILLIS;
-        } else if (this->auth_data_update_) {
-            ESP_LOGD(TAG, "Requesting auth data...");
-            this->update_auth_data();
-            command_cooldown_millis = COOLDOWN_COMMANDS_MILLIS;
-        } else if (this->event_log_update_) {
-            ESP_LOGD(TAG, "Requesting event logs...");
-            this->update_event_logs();
-            command_cooldown_millis = COOLDOWN_COMMANDS_MILLIS;
-        } else if (this->advanced_config_update_) {
-            ESP_LOGD(TAG, "Requesting advanced config...");
-            this->update_advanced_config();
-            command_cooldown_millis = COOLDOWN_COMMANDS_MILLIS;
-        }
-
-        last_command_executed_time_ = millis();
-
-    } else {
-        this->connected_ = false;
-
-        #ifdef USE_BINARY_SENSOR
-        if (this->paired_binary_sensor_ != nullptr) {
-            this->paired_binary_sensor_->publish_state(false);
-        }
-        if (this->connected_binary_sensor_ != nullptr) {
-            this->connected_binary_sensor_->publish_state(connected_);
-        }
-        #endif
-
-        // Pairing Mode is active
-        if (this->pairing_mode_) {
-            // Pair Nuki
-            Nuki::AuthorizationIdType type = this->pairing_as_app_.value_or(false) ? Nuki::AuthorizationIdType::App : Nuki::AuthorizationIdType::Bridge;
-            
-            App.feed_wdt();
-
-            bool paired = this->nuki_lock_.pairNuki(type) == Nuki::PairingResult::Success;
-
-            App.feed_wdt();
-
-            if (paired) {
-                const char* pairing_type = this->pairing_as_app_.value_or(false) ? "App" : "Bridge";
-                const char* lock_type = this->nuki_lock_.isLockUltra() ? "Ultra / Go / 5th Gen" : "1st - 4th Gen";
-                ESP_LOGI(TAG, "Successfully paired as %s with a %s smart lock!", pairing_type, lock_type);
-
-                this->update_status();
-                this->paired_callback_.call();
-                this->set_pairing_mode(false);
-
-                // Save initial security pin after pairing
-                // Pairing resets the security pin
-                const uint32_t pin_to_use = this->security_pin_ != 0 ? this->security_pin_ : this->security_pin_config_.value_or(0);
-
-                if (this->security_pin_ != 0) {
-                    ESP_LOGW(TAG, "Using security pin override instead of YAML config");
-                }
-
-                if (pin_to_use == 0) {
-                    ESP_LOGD(TAG, "No security pin configured, skipping pin setup");
-                    this->pin_state_ = PinState::NotSet;
-                    this->save_settings();
-                    this->publish_pin_state();
-                } else if (pin_to_use > 999999) {
-                    ESP_LOGE(TAG, "Invalid security pin detected! Maximum is 6 digits (999999)");
-                    this->pin_state_ = PinState::Invalid;
-                    this->save_settings();
-                    this->publish_pin_state();
-                } else if (!this->nuki_lock_.isLockUltra() && pin_to_use > 65535) {
-                    ESP_LOGE(TAG, "Security pin exceeds maximum of 65535 for 1st-4th gen locks", pin_to_use);
-                    this->pin_state_ = PinState::Invalid;
-                    this->save_settings();
-                    this->publish_pin_state();
-                } else {
-                    const bool result = this->nuki_lock_.isLockUltra() ? this->nuki_lock_.saveUltraPincode(pin_to_use) : this->nuki_lock_.saveSecurityPincode(static_cast<uint16_t>(pin_to_use));
-
-                    if (result) {
-                        ESP_LOGI(TAG, "Successfully set security pin");
-                    } else {
-                        ESP_LOGE(TAG, "Failed to set security pin");
-                    }
-
-                    this->save_settings();
-                    this->publish_pin_state();
-                    this->validate_pin();
-                }
-
-                this->setup_intervals();
-            }
-
-            #ifdef USE_BINARY_SENSOR
-            if (this->paired_binary_sensor_ != nullptr) {
-                this->paired_binary_sensor_->publish_state(paired);
-            }
-            #endif
-        }    
     }
 }
 
@@ -1699,6 +1231,7 @@ void NukiLockComponent::add_keypad_entry(std::string name, int32_t code) {
     size_t name_len = name.length();
     memcpy(&entry.name, name.c_str(), name_len > 20 ? 20 : name_len);
     entry.code = code;
+
     Nuki::CmdResult result = this->nuki_lock_.addKeypadEntry(entry);
     if (result == Nuki::CmdResult::Success) {
         ESP_LOGI(TAG, "add_keypad_entry is sucessful");
@@ -1735,6 +1268,7 @@ void NukiLockComponent::update_keypad_entry(int32_t id, std::string name, int32_
     memcpy(&entry.name, name.c_str(), name_len > 20 ? 20 : name_len);
     entry.code = code;
     entry.enabled = enabled ? 1 : 0;
+
     Nuki::CmdResult result = this->nuki_lock_.updateKeypadEntry(entry);
     if (result == Nuki::CmdResult::Success) {
         ESP_LOGI(TAG, "update_keypad_entry is sucessful");
@@ -1830,8 +1364,10 @@ void NukiLockComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  BLE command timeout: %us", this->ble_command_timeout_);
 
     char pin_state_as_string[30] = {0};
-    this->pin_state_to_string(this->pin_state_, pin_state_as_string);
+    nuki_lock::pin_state_to_string(this->pin_state_, pin_state_as_string);
     ESP_LOGCONFIG(TAG, "  Last known security pin state: %s", pin_state_as_string);
+
+    ESP_LOGCONFIG(TAG, "  Task Stack High Watermark: %i", (uint16_t)uxTaskGetStackHighWaterMark(nuki_task_handle_));
 
     LOG_LOCK(TAG, "Nuki Lock", this);
     #ifdef USE_BINARY_SENSOR
@@ -1908,8 +1444,8 @@ void NukiLockComponent::notify(Nuki::EventType event_type) {
         // Invalid Pin
         ESP_LOGW(TAG, "Nuki reported an invalid security PIN");
 
-        ESP_LOGD(TAG, "NVS PIN (Gen 1-4): %d", this->nuki_lock_.getSecurityPincode());
-        ESP_LOGD(TAG, "NVS PIN (Ultra/Go/Pro/Gen 5): %d", this->nuki_lock_.getUltraPincode());
+        ESP_LOGD(TAG, "NVS PIN 1st-4th Gen: %d", this->nuki_lock_.getSecurityPincode());
+        ESP_LOGD(TAG, "NVS PIN 5th Gen (Ultra / Go / Pro): %d", this->nuki_lock_.getUltraPincode());
         ESP_LOGD(TAG, "ESPHome PIN (override): %d", this->security_pin_);
         ESP_LOGD(TAG, "ESPHome PIN (YAML): %d", this->security_pin_config_.value_or(0));
 
@@ -1929,7 +1465,7 @@ void NukiLockComponent::notify(Nuki::EventType event_type) {
         // Request status update (incl. event log request)
         this->status_update_ = true;
     } else if(event_type == Nuki::EventType::BLE_ERROR_ON_DISCONNECT) {
-        ESP_LOGE(TAG, "Failed to disconnect from Nuki. Restarting ESP...");
+        ESP_LOGE(TAG, "Failed to disconnect from Nuki. Restarting ESPHome...");
         delay(100);  // NOLINT
         App.safe_reboot();
     }
@@ -1959,6 +1495,7 @@ void NukiLockComponent::unpair() {
     this->save_settings();
 
     this->setup_intervals(false);
+    this->pin_validation_pending_ = false;
 
     ESP_LOGI(TAG, "Unpaired Nuki! Turn on Pairing Mode to pair a new Nuki.");
 }
@@ -1997,11 +1534,11 @@ void NukiLockComponent::set_pairing_mode(bool enabled) {
         } else if(this->security_pin_config_.value_or(0) != 0) {
             ESP_LOGD(TAG, "Using security pin from yaml config to pair.");
         } else {
-            ESP_LOGW(TAG, "Note: The security pin is crucial to pair a Smart Lock Ultra but is currently not set.");
+            ESP_LOGW(TAG, "Note: The security pin is crucial to pair a 5th Gen Smart Lock (Ultra / Go / Pro) but is currently not set.");
         }
 
-        ESP_LOGD(TAG, "NVS PIN (Gen 1-4): %d", this->nuki_lock_.getSecurityPincode());
-        ESP_LOGD(TAG, "NVS PIN (Ultra/Go/Pro/Gen 5): %d", this->nuki_lock_.getUltraPincode());
+        ESP_LOGD(TAG, "NVS PIN 1st-4th Gen: %d", this->nuki_lock_.getSecurityPincode());
+        ESP_LOGD(TAG, "NVS PIN 5th Gen (Ultra / Go / Pro): %d", this->nuki_lock_.getUltraPincode());
         ESP_LOGD(TAG, "ESPHome PIN (override): %d", this->security_pin_);
         ESP_LOGD(TAG, "ESPHome PIN (YAML): %d", this->security_pin_config_.value_or(0));
 
@@ -2018,268 +1555,6 @@ void NukiLockComponent::set_pairing_mode(bool enabled) {
     }
 }
 
-#ifdef USE_SELECT
-void NukiLockComponent::set_config_select(const char* config, const char* value) {
-    if (!this->nuki_lock_.isPairedWithLock()) {
-        ESP_LOGE(TAG, "Lock is not paired, cannot change setting %s", config);
-        return;
-    }
-
-    Nuki::CmdResult cmd_result = (Nuki::CmdResult)-1;
-    bool is_advanced = false;
-
-    // Update Config
-    if (strcmp(config, "single_button_press_action") == 0) {
-        NukiLock::ButtonPressAction action = this->button_press_action_to_enum(value);
-        cmd_result = this->nuki_lock_.setSingleButtonPressAction(action);
-        is_advanced = true;
-    } else if (strcmp(config, "double_button_press_action") == 0) {
-        NukiLock::ButtonPressAction action = this->button_press_action_to_enum(value);
-        cmd_result = this->nuki_lock_.setDoubleButtonPressAction(action);
-        is_advanced = true;
-    } else if (strcmp(config, "fob_action_1") == 0) {
-        const uint8_t action = this->fob_action_to_int(value);
-        if (action != 99) {
-            cmd_result = this->nuki_lock_.setFobAction(1, action);
-        }
-    } else if (strcmp(config, "fob_action_2") == 0) {
-        const uint8_t action = this->fob_action_to_int(value);
-        if (action != 99) {
-            cmd_result = this->nuki_lock_.setFobAction(2, action);
-        }
-    } else if (strcmp(config, "fob_action_3") == 0) {
-        const uint8_t action = this->fob_action_to_int(value);
-        if (action != 99) {
-            cmd_result = this->nuki_lock_.setFobAction(3, action);
-        }
-    } else if (strcmp(config, "timezone") == 0) {
-        Nuki::TimeZoneId tzid = this->timezone_to_enum(value);
-        cmd_result = this->nuki_lock_.setTimeZoneId(tzid);
-    } else if (strcmp(config, "advertising_mode") == 0) {
-        Nuki::AdvertisingMode mode = this->advertising_mode_to_enum(value);
-        cmd_result = this->nuki_lock_.setAdvertisingMode(mode);
-    } else if (!this->nuki_lock_.isLockUltra() && strcmp(config, "battery_type") == 0) {
-        Nuki::BatteryType type = this->battery_type_to_enum(value);
-        cmd_result = this->nuki_lock_.setBatteryType(type);
-        is_advanced = true;
-    } else if (this->nuki_lock_.isLockUltra() && strcmp(config, "motor_speed") == 0) {
-        NukiLock::MotorSpeed speed = this->motor_speed_to_enum(value);
-        cmd_result = this->nuki_lock_.setMotorSpeed(speed);
-        is_advanced = true;
-    }
-
-    if (cmd_result == Nuki::CmdResult::Success) {
-        if (strcmp(config, "single_button_press_action") == 0 && this->single_button_press_action_select_ != nullptr) {
-            this->single_button_press_action_select_->publish_state(value);
-        } else if (strcmp(config, "double_button_press_action") == 0 && this->double_button_press_action_select_ != nullptr) {
-            this->double_button_press_action_select_->publish_state(value);
-        } else if (strcmp(config, "fob_action_1") == 0 && this->fob_action_1_select_ != nullptr) {
-            this->fob_action_1_select_->publish_state(value);
-        } else if (strcmp(config, "fob_action_2") == 0 && this->fob_action_2_select_ != nullptr) {
-            this->fob_action_2_select_->publish_state(value);
-        } else if (strcmp(config, "fob_action_3") == 0 && this->fob_action_3_select_ != nullptr) {
-            this->fob_action_3_select_->publish_state(value);
-        } else if (strcmp(config, "timezone") == 0 && this->timezone_select_ != nullptr) {
-            this->timezone_select_->publish_state(value);
-        } else if (strcmp(config, "advertising_mode") == 0 && this->advertising_mode_select_ != nullptr) {
-            this->advertising_mode_select_->publish_state(value);
-        } else if (!this->nuki_lock_.isLockUltra() && strcmp(config, "battery_type") == 0 && this->battery_type_select_ != nullptr) {
-            this->battery_type_select_->publish_state(value);
-        } else if (this->nuki_lock_.isLockUltra() && strcmp(config, "motor_speed") == 0 && this->motor_speed_select_ != nullptr) {
-            this->motor_speed_select_->publish_state(value);
-        }
-        
-        this->config_update_ = !is_advanced;
-        this->advanced_config_update_ = is_advanced;
-    } else {
-        ESP_LOGE(TAG, "Saving setting %s failed (result %d)", config, cmd_result);
-    }
-}
-#endif
-
-#ifdef USE_SWITCH
-void NukiLockComponent::set_config_switch(const char* config, bool value) {
-    if (!this->nuki_lock_.isPairedWithLock()) {
-        ESP_LOGE(TAG, "Lock is not paired, cannot change setting %s", config);
-        return;
-    }
-
-    Nuki::CmdResult cmd_result = (Nuki::CmdResult)-1;
-    bool is_advanced = false;
-
-    // Update Config
-    if (strcmp(config, "pairing_enabled") == 0) {
-        cmd_result = this->nuki_lock_.enablePairing(value);
-    } else if (strcmp(config, "auto_unlatch_enabled") == 0) {
-        cmd_result = this->nuki_lock_.enableAutoUnlatch(value);
-    } else if (strcmp(config, "button_enabled") == 0) {
-        cmd_result = this->nuki_lock_.enableButton(value);
-    } else if (strcmp(config, "led_enabled") == 0) {
-        cmd_result = this->nuki_lock_.enableLedFlash(value);
-    } else if (strcmp(config, "nightmode_enabled") == 0) {
-        cmd_result = this->nuki_lock_.enableNightMode(value);
-        is_advanced = true;
-    } else if (strcmp(config, "night_mode_auto_lock_enabled") == 0) {
-        cmd_result = this->nuki_lock_.enableNightModeAutoLock(value);
-        is_advanced = true;
-    } else if (strcmp(config, "night_mode_auto_unlock_disabled") == 0) {
-        cmd_result = this->nuki_lock_.disableNightModeAutoUnlock(value);
-        is_advanced = true;
-    } else if (strcmp(config, "night_mode_immediate_lock_on_start") == 0) {
-        cmd_result = this->nuki_lock_.enableNightModeImmediateLockOnStart(value);
-        is_advanced = true;
-    } else if (strcmp(config, "auto_lock_enabled") == 0) {
-        cmd_result = this->nuki_lock_.enableAutoLock(value);
-        is_advanced = true;
-    } else if (strcmp(config, "auto_unlock_disabled") == 0) {
-        cmd_result = this->nuki_lock_.disableAutoUnlock(value);
-        is_advanced = true;
-    } else if (strcmp(config, "immediate_auto_lock_enabled") == 0) {
-        cmd_result = this->nuki_lock_.enableImmediateAutoLock(value);
-        is_advanced = true;
-    } else if (strcmp(config, "auto_update_enabled") == 0) {
-        cmd_result = this->nuki_lock_.enableAutoUpdate(value);
-        is_advanced = true;
-    } else if (strcmp(config, "single_lock_enabled") == 0) {
-        cmd_result = this->nuki_lock_.enableSingleLock(value);
-    } else if (strcmp(config, "dst_mode_enabled") == 0) {
-        cmd_result = this->nuki_lock_.enableDst(value);
-    } else if (!this->nuki_lock_.isLockUltra() && strcmp(config, "auto_battery_type_detection_enabled") == 0) {
-        cmd_result = this->nuki_lock_.enableAutoBatteryTypeDetection(value);
-    } else if (this->nuki_lock_.isLockUltra() && strcmp(config, "slow_speed_during_night_mode_enabled") == 0) {
-        cmd_result = this->nuki_lock_.enableSlowSpeedDuringNightMode(value);
-    } else if (strcmp(config, "detached_cylinder_enabled") == 0) {
-        cmd_result = this->nuki_lock_.enableDetachedCylinder(value);
-    }
-
-    if (cmd_result == Nuki::CmdResult::Success)
-    {
-        if (strcmp(config, "pairing_enabled") == 0 && this->pairing_enabled_switch_ != nullptr) {
-            this->pairing_enabled_switch_->publish_state(value);
-        } else if (strcmp(config, "auto_unlatch_enabled") == 0 && this->auto_unlatch_enabled_switch_ != nullptr) {
-            this->auto_unlatch_enabled_switch_->publish_state(value);
-        } else if (strcmp(config, "button_enabled") == 0 && this->button_enabled_switch_ != nullptr) {
-            this->button_enabled_switch_->publish_state(value);
-        } else if (strcmp(config, "led_enabled") == 0 && this->led_enabled_switch_ != nullptr) {
-            this->led_enabled_switch_->publish_state(value);
-        } else if (strcmp(config, "nightmode_enabled") == 0 && this->nightmode_enabled_switch_ != nullptr) {
-            this->nightmode_enabled_switch_->publish_state(value);
-        } else if (strcmp(config, "night_mode_auto_lock_enabled") == 0 && this->night_mode_auto_lock_enabled_switch_ != nullptr) {
-            this->night_mode_auto_lock_enabled_switch_->publish_state(value);
-        } else if (strcmp(config, "night_mode_auto_unlock_disabled") == 0 && this->night_mode_auto_unlock_disabled_switch_ != nullptr) {
-            this->night_mode_auto_unlock_disabled_switch_->publish_state(value);
-        } else if (strcmp(config, "night_mode_immediate_lock_on_start") == 0 && this->night_mode_immediate_lock_on_start_switch_ != nullptr) {
-            this->night_mode_immediate_lock_on_start_switch_->publish_state(value);
-        } else if (strcmp(config, "auto_lock_enabled") == 0 && this->auto_lock_enabled_switch_ != nullptr) {
-            this->auto_lock_enabled_switch_->publish_state(value);
-        } else if (strcmp(config, "auto_unlock_disabled") == 0 && this->auto_unlock_disabled_switch_ != nullptr) {
-            this->auto_unlock_disabled_switch_->publish_state(value);
-        } else if (strcmp(config, "immediate_auto_lock_enabled") == 0 && this->immediate_auto_lock_enabled_switch_ != nullptr) {
-            this->immediate_auto_lock_enabled_switch_->publish_state(value);
-        } else if (strcmp(config, "auto_update_enabled") == 0 && this->auto_update_enabled_switch_ != nullptr) {
-            this->auto_update_enabled_switch_->publish_state(value);
-        } else if (strcmp(config, "single_lock_enabled") == 0 && this->single_lock_enabled_switch_ != nullptr) {
-            this->single_lock_enabled_switch_->publish_state(value);
-        } else if (strcmp(config, "dst_mode_enabled") == 0 && this->dst_mode_enabled_switch_ != nullptr) {
-            this->dst_mode_enabled_switch_->publish_state(value);
-        } else if (!this->nuki_lock_.isLockUltra() && strcmp(config, "auto_battery_type_detection_enabled") == 0 && this->auto_battery_type_detection_enabled_switch_ != nullptr) {
-            this->auto_battery_type_detection_enabled_switch_->publish_state(value);
-        } else if (this->nuki_lock_.isLockUltra() && strcmp(config, "slow_speed_during_night_mode_enabled") == 0 && this->slow_speed_during_night_mode_enabled_switch_ != nullptr) {
-            this->slow_speed_during_night_mode_enabled_switch_->publish_state(value);
-        } else if (strcmp(config, "detached_cylinder_enabled") == 0 && this->detached_cylinder_enabled_switch_ != nullptr) {
-            this->detached_cylinder_enabled_switch_->publish_state(value);
-        }
-
-        this->config_update_ = !is_advanced;
-        this->advanced_config_update_ = is_advanced;
-    } else {
-        ESP_LOGE(TAG, "Saving setting %s failed (result %d)", config, cmd_result);
-    }
-}
-#endif
-#ifdef USE_NUMBER
-void NukiLockComponent::set_config_number(const char* config, float value) {
-    if (!this->nuki_lock_.isPairedWithLock()) {
-        ESP_LOGE(TAG, "Lock is not paired, cannot change setting %s", config);
-        return;
-    }
-
-    Nuki::CmdResult cmd_result = (Nuki::CmdResult)-1;
-    bool is_advanced = false;
-
-    // Update Config
-    if (strcmp(config, "led_brightness") == 0) {
-        cmd_result = this->nuki_lock_.setLedBrightness(value);
-    } else if (strcmp(config, "timezone_offset") == 0) {
-        if (value >= -60 && value <= 60) {
-            cmd_result = this->nuki_lock_.setTimeZoneOffset(value);
-        }
-    } else if (strcmp(config, "lock_n_go_timeout") == 0) {
-        if (value >= 5 && value <= 60) {
-            cmd_result = this->nuki_lock_.setLockNgoTimeout(value);
-            is_advanced = true;
-        }
-    } else if (strcmp(config, "auto_lock_timeout") == 0) {
-        if (value >= 30 && value <= 1800) {
-            cmd_result = this->nuki_lock_.setAutoLockTimeOut(value);
-            is_advanced = true;
-        }
-    } else if (strcmp(config, "unlatch_duration") == 0) {
-        if (value >= 1 && value <= 30) {
-            cmd_result = this->nuki_lock_.setUnlatchDuration(value);
-            is_advanced = true;
-        }
-    } else if (strcmp(config, "unlocked_position_offset") == 0) {
-        if (value >= -90 && value <= 180) {
-            cmd_result = this->nuki_lock_.setUnlockedPositionOffsetDegrees(value);
-            is_advanced = true;
-        }
-    } else if (strcmp(config, "locked_position_offset") == 0) {
-        if (value >= -180 && value <= 90) {
-            cmd_result = this->nuki_lock_.setLockedPositionOffsetDegrees(value);
-            is_advanced = true;
-        }
-    } else if (strcmp(config, "single_locked_position_offset") == 0) {
-        if (value >= -180 && value <= 180) {
-            cmd_result = this->nuki_lock_.setSingleLockedPositionOffsetDegrees(value);
-            is_advanced = true;
-        }
-    } else if (strcmp(config, "unlocked_to_locked_transition_offset") == 0) {
-        if (value >= -180 && value <= 180) {
-            cmd_result = this->nuki_lock_.setUnlockedToLockedTransitionOffsetDegrees(value);
-            is_advanced = true;
-        }
-    }
-
-    if (cmd_result == Nuki::CmdResult::Success) {
-        if (strcmp(config, "led_brightness") == 0 && this->led_brightness_number_ != nullptr) {
-            this->led_brightness_number_->publish_state(value);
-        } else if (strcmp(config, "timezone_offset") == 0 && this->timezone_offset_number_ != nullptr) {
-            this->timezone_offset_number_->publish_state(value);
-        } else if (strcmp(config, "lock_n_go_timeout") == 0 && this->lock_n_go_timeout_number_ != nullptr) {
-            this->lock_n_go_timeout_number_->publish_state(value);
-        } else if (strcmp(config, "auto_lock_timeout") == 0 && this->auto_lock_timeout_number_ != nullptr) {
-            this->auto_lock_timeout_number_->publish_state(value);
-        } else if (strcmp(config, "unlatch_duration") == 0 && this->unlatch_duration_number_ != nullptr) {
-            this->unlatch_duration_number_->publish_state(value);
-        } else if (strcmp(config, "unlocked_position_offset") == 0 && this->unlocked_position_offset_number_ != nullptr) {
-            this->unlocked_position_offset_number_->publish_state(value);
-        } else if (strcmp(config, "locked_position_offset") == 0 && this->locked_position_offset_number_ != nullptr) {
-            this->locked_position_offset_number_->publish_state(value);
-        } else if (strcmp(config, "single_locked_position_offset") == 0 && this->single_locked_position_offset_number_ != nullptr) {
-            this->single_locked_position_offset_number_->publish_state(value);
-        } else if (strcmp(config, "unlocked_to_locked_transition_offset") == 0 && this->unlocked_to_locked_transition_offset_number_ != nullptr) {
-            this->unlocked_to_locked_transition_offset_number_->publish_state(value);
-        }
-        
-        this->config_update_ = !is_advanced;
-        this->advanced_config_update_ = is_advanced;
-    } else {
-        ESP_LOGE(TAG, "Saving setting %s failed (result %d)", config, cmd_result);
-    }
-}
-#endif
-
 #ifdef USE_BUTTON
 void NukiLockUnpairButton::press_action() {
     this->parent_->unpair();
@@ -2290,40 +1565,84 @@ void NukiLockRequestCalibrationButton::press_action() {
 }
 #endif
 #ifdef USE_SELECT
-void NukiLockSingleButtonPressActionSelect::control(const std::string &action) {
-    this->parent_->set_config_select("single_button_press_action", action.c_str());
+void NukiLockSingleButtonPressActionSelect::control(const std::string &value) {
+    NukiLock::ButtonPressAction action = nuki_lock::button_press_action_to_enum(value.c_str());
+    if(this->parent_->get_nuki_lock()->setSingleButtonPressAction(action)) {
+        this->parent_->get_nuki_lock_advanced_config()->singleButtonPressAction = action;
+        this->publish_state(value.c_str());
+    }
 }
 
-void NukiLockDoubleButtonPressActionSelect::control(const std::string &action) {
-    this->parent_->set_config_select("double_button_press_action", action.c_str());
+void NukiLockDoubleButtonPressActionSelect::control(const std::string &value) {
+    NukiLock::ButtonPressAction action = nuki_lock::button_press_action_to_enum(value.c_str());
+    if(this->parent_->get_nuki_lock()->setDoubleButtonPressAction(action)) {
+        this->parent_->get_nuki_lock_advanced_config()->doubleButtonPressAction = action;
+        this->publish_state(value.c_str());
+    }
 }
 
-void NukiLockFobAction1Select::control(const std::string &action) {
-    this->parent_->set_config_select("fob_action_1", action.c_str());
+void NukiLockFobAction1Select::control(const std::string &value) {
+    const uint8_t action = nuki_lock::fob_action_to_int(value.c_str());
+    if (action != 99 && this->parent_->get_nuki_lock()->setFobAction(1, action)) {
+        this->parent_->get_nuki_lock_config()->fobAction1 = action;
+        this->publish_state(value.c_str());
+    }
 }
 
-void NukiLockFobAction2Select::control(const std::string &action) {
-    this->parent_->set_config_select("fob_action_2", action.c_str());
+void NukiLockFobAction2Select::control(const std::string &value) {
+    const uint8_t action = nuki_lock::fob_action_to_int(value.c_str());
+    if (action != 99 && this->parent_->get_nuki_lock()->setFobAction(2, action)) {
+        this->parent_->get_nuki_lock_config()->fobAction2 = action;
+        this->publish_state(value.c_str());
+    }
 }
 
-void NukiLockFobAction3Select::control(const std::string &action) {
-    this->parent_->set_config_select("fob_action_3", action.c_str());
+void NukiLockFobAction3Select::control(const std::string &value) {
+    const uint8_t action = nuki_lock::fob_action_to_int(value.c_str());
+    if (action != 99 && this->parent_->get_nuki_lock()->setFobAction(3, action)) {
+        this->parent_->get_nuki_lock_config()->fobAction3 = action;
+        this->publish_state(value.c_str());
+    }
 }
 
-void NukiLockTimeZoneSelect::control(const std::string &zone) {
-    this->parent_->set_config_select("timezone", zone.c_str());
+void NukiLockTimeZoneSelect::control(const std::string &value) {
+    Nuki::TimeZoneId tzid = nuki_lock::timezone_to_enum(value.c_str());
+    if(this->parent_->get_nuki_lock()->setTimeZoneId(tzid)) {
+        this->parent_->get_nuki_lock_config()->timeZoneId = tzid;
+        this->publish_state(value.c_str());
+    }
 }
 
-void NukiLockAdvertisingModeSelect::control(const std::string &mode) {
-    this->parent_->set_config_select("advertising_mode", mode.c_str());
+void NukiLockAdvertisingModeSelect::control(const std::string &value) {
+    Nuki::AdvertisingMode mode = nuki_lock::advertising_mode_to_enum(value.c_str());
+    if(this->parent_->get_nuki_lock()->setAdvertisingMode(mode)) {
+        this->parent_->get_nuki_lock_config()->advertisingMode = mode;
+        this->publish_state(value.c_str());
+    }
 }
 
-void NukiLockBatteryTypeSelect::control(const std::string &mode) {
-    this->parent_->set_config_select("battery_type", mode.c_str());
+void NukiLockBatteryTypeSelect::control(const std::string &value) {
+    if(!this->parent_->get_nuki_lock()->isLockUltra()) {
+        Nuki::BatteryType type = nuki_lock::battery_type_to_enum(value.c_str());
+        if(this->parent_->get_nuki_lock()->setBatteryType(type)) {
+            this->parent_->get_nuki_lock_advanced_config()->batteryType = type;
+            this->publish_state(value.c_str());
+        }
+    } else {
+        ESP_LOGE(TAG, "Battery Type is not supported for 5th Gen Smart Locks (Ultra / Go / Pro)");
+    }
 }
 
-void NukiLockMotorSpeedSelect::control(const std::string &mode) {
-    this->parent_->set_config_select("motor_speed", mode.c_str());
+void NukiLockMotorSpeedSelect::control(const std::string &value) {
+    if(this->parent_->get_nuki_lock()->isLockUltra()) {
+        NukiLock::MotorSpeed speed = nuki_lock::motor_speed_to_enum(value.c_str());
+        if(this->parent_->get_nuki_lock()->setMotorSpeed(speed)) {
+            this->parent_->get_nuki_lock_advanced_config()->motorSpeed = speed;
+            this->publish_state(value.c_str());
+        }
+    } else {
+        ESP_LOGE(TAG, "Motor Speed is only supported for 5th Gen Smart Locks (Ultra / Go / Pro)");
+    }
 }
 #endif
 #ifdef USE_SWITCH
@@ -2332,99 +1651,201 @@ void NukiLockPairingModeSwitch::write_state(bool state) {
 }
 
 void NukiLockPairingEnabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("pairing_enabled", state);
+    if(this->parent_->get_nuki_lock()->enablePairing(state)) {
+        this->parent_->get_nuki_lock_config()->pairingEnabled = state;
+        this->publish_state(state);
+    }
 }
 
 void NukiLockAutoUnlatchEnabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("auto_unlatch_enabled", state);
+    if(this->parent_->get_nuki_lock()->enableAutoUnlatch(state)) {
+        this->parent_->get_nuki_lock_config()->autoUnlatch = state;
+        this->publish_state(state);
+    }
 }
 
 void NukiLockButtonEnabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("button_enabled", state);
+    if(this->parent_->get_nuki_lock()->enableButton(state)) {
+        this->parent_->get_nuki_lock_config()->buttonEnabled = state;
+        this->publish_state(state);
+    }
 }
 
 void NukiLockLedEnabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("led_enabled", state);
+    if(this->parent_->get_nuki_lock()->enableLedFlash(state)) {
+        this->parent_->get_nuki_lock_config()->ledEnabled = state;
+        this->publish_state(state);
+    }
 }
 
 void NukiLockNightModeEnabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("nightmode_enabled", state);
+    if(this->parent_->get_nuki_lock()->enableNightMode(state)) {
+        this->parent_->get_nuki_lock_advanced_config()->nightModeEnabled = state;
+        this->publish_state(state);
+    }
 }
 
 void NukiLockNightModeAutoLockEnabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("night_mode_auto_lock_enabled", state);
+    if(this->parent_->get_nuki_lock()->enableNightModeAutoLock(state)) {
+        this->parent_->get_nuki_lock_advanced_config()->nightModeAutoLockEnabled = state;
+        this->publish_state(state);
+    }
 }
 
 void NukiLockNightModeAutoUnlockDisabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("night_mode_auto_unlock_disabled", state);
+    if(this->parent_->get_nuki_lock()->disableNightModeAutoUnlock(state)) {
+        this->parent_->get_nuki_lock_advanced_config()->nightModeAutoUnlockDisabled = state;
+        this->publish_state(state);
+    }
 }
 
 void NukiLockNightModeImmediateLockOnStartEnabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("night_mode_immediate_lock_on_start", state);
+    if(this->parent_->get_nuki_lock()->enableNightModeImmediateLockOnStart(state)) {
+        this->parent_->get_nuki_lock_advanced_config()->nightModeImmediateLockOnStart = state;
+        this->publish_state(state);
+    }
 }
 
 void NukiLockAutoLockEnabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("auto_lock_enabled", state);
+    if(this->parent_->get_nuki_lock()->enableAutoLock(state)) {
+        this->parent_->get_nuki_lock_advanced_config()->autoLockEnabled = state;
+        this->publish_state(state);
+    }
 }
 
 void NukiLockAutoUnlockDisabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("auto_unlock_disabled", state);
+    if(this->parent_->get_nuki_lock()->disableAutoUnlock(state)) {
+        this->parent_->get_nuki_lock_advanced_config()->autoUnLockDisabled = state;
+        this->publish_state(state);
+    }
 }
 
 void NukiLockImmediateAutoLockEnabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("immediate_auto_lock_enabled", state);
+    if(this->parent_->get_nuki_lock()->enableImmediateAutoLock(state)) {
+        this->parent_->get_nuki_lock_advanced_config()->immediateAutoLockEnabled = state;
+        this->publish_state(state);
+    }
 }
 
 void NukiLockAutoUpdateEnabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("auto_update_enabled", state);
+    if(this->parent_->get_nuki_lock()->enableAutoUpdate(state)) {
+        this->parent_->get_nuki_lock_advanced_config()->autoUpdateEnabled = state;
+        this->publish_state(state);
+    }
 }
 
 void NukiLockSingleLockEnabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("single_lock_enabled", state);
+    if(this->parent_->get_nuki_lock()->enableSingleLock(state)) {
+        this->parent_->get_nuki_lock_config()->singleLock = state;
+        this->publish_state(state);
+    }
 }
 
 void NukiLockDstModeEnabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("dst_mode_enabled", state);
+    if(this->parent_->get_nuki_lock()->enableDst(state)) {
+        this->parent_->get_nuki_lock_config()->dstMode = state;
+        this->publish_state(state);
+    }
 }
 
 void NukiLockAutoBatteryTypeDetectionEnabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("auto_battery_type_detection_enabled", state);
+    if(!this->parent_->get_nuki_lock()->isLockUltra()) {
+        if(this->parent_->get_nuki_lock()->enableAutoBatteryTypeDetection(state)) {
+            this->parent_->get_nuki_lock_advanced_config()->automaticBatteryTypeDetection = state;
+            this->publish_state(state);
+        }
+    } else {
+        ESP_LOGE(TAG, "Auto Battery Type Detection is not supported for 5th Gen Smart Locks (Ultra / Go / Pro)");
+    }
 }
 
 void NukiLockSlowSpeedDuringNightModeEnabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("slow_speed_during_night_mode_enabled", state);
+    if(this->parent_->get_nuki_lock()->isLockUltra()) {
+        if(this->parent_->get_nuki_lock()->enableSlowSpeedDuringNightMode(state)) {
+            this->parent_->get_nuki_lock_advanced_config()->enableSlowSpeedDuringNightMode = state;
+            this->publish_state(state);
+        }
+    } else {
+        ESP_LOGE(TAG, "Slow Speed During Night Mode is only supported for 5th Gen Smart Locks (Ultra / Go / Pro)");
+    }
 }
 void NukiLockDetachedCylinderEnabledSwitch::write_state(bool state) {
-    this->parent_->set_config_switch("detached_cylinder_enabled", state);
+    if(this->parent_->get_nuki_lock()->enableDetachedCylinder(state)) {
+        this->parent_->get_nuki_lock_advanced_config()->detachedCylinder = state;
+        this->publish_state(state);
+    }
 }
 #endif
 #ifdef USE_NUMBER
 void NukiLockLedBrightnessNumber::control(float value) {
-    this->parent_->set_config_number("led_brightness", value);
+    if(this->parent_->get_nuki_lock()->setLedBrightness(value)) {
+        this->parent_->get_nuki_lock_config()->ledBrightness = value;
+        this->publish_state(value);
+    }
 }
 void NukiLockTimeZoneOffsetNumber::control(float value) {
-    this->parent_->set_config_number("timezone_offset", value);
+    if (value >= -60 && value <= 60) {
+        if(this->parent_->get_nuki_lock()->setTimeZoneOffset(value)) {
+            this->parent_->get_nuki_lock_config()->timeZoneOffset = value;
+            this->publish_state(value);
+        }
+    }
 }
 void NukiLockLockNGoTimeoutNumber::control(float value) {
-    this->parent_->set_config_number("lock_n_go_timeout", value);
+    if (value >= 5 && value <= 60) {
+        if(this->parent_->get_nuki_lock()->setLockNgoTimeout(value)) {
+            this->parent_->get_nuki_lock_advanced_config()->lockNgoTimeout = value;
+            this->publish_state(value);
+        }
+    }
 }
 void NukiLockAutoLockTimeoutNumber::control(float value) {
-    this->parent_->set_config_number("auto_lock_timeout", value);
+    if (value >= 30 && value <= 1800) {
+        if(this->parent_->get_nuki_lock()->setAutoLockTimeOut(value)) {
+            this->parent_->get_nuki_lock_advanced_config()->autoLockTimeOut = value;
+            this->publish_state(value);
+        }
+    }
 }
 void NukiLockUnlatchDurationNumber::control(float value) {
-    this->parent_->set_config_number("unlatch_duration", value);
+    if (value >= 1 && value <= 30) {
+        if(this->parent_->get_nuki_lock()->setUnlatchDuration(value)) {
+            this->parent_->get_nuki_lock_advanced_config()->unlatchDuration = value;
+            this->publish_state(value);
+        }
+    }
 }
 void NukiLockUnlockedPositionOffsetDegreesNumber::control(float value) {
-    this->parent_->set_config_number("unlocked_position_offset", value);
+    if (value >= -90 && value <= 180) {
+        if(this->parent_->get_nuki_lock()->setUnlockedPositionOffsetDegrees(value)) {
+            this->parent_->get_nuki_lock_advanced_config()->unlockedPositionOffsetDegrees = value;
+            this->publish_state(value);
+        }
+    }
 }
 void NukiLockLockedPositionOffsetDegreesNumber::control(float value) {
-    this->parent_->set_config_number("locked_position_offset", value);
+    if (value >= -180 && value <= 90) {
+        if(this->parent_->get_nuki_lock()->setLockedPositionOffsetDegrees(value)) {
+            this->parent_->get_nuki_lock_advanced_config()->lockedPositionOffsetDegrees = value;
+            this->publish_state(value);
+        }
+    }
 }
 void NukiLockSingleLockedPositionOffsetDegreesNumber::control(float value) {
-    this->parent_->set_config_number("single_locked_position_offset", value);
+    if (value >= -180 && value <= 180) {
+        if(this->parent_->get_nuki_lock()->setSingleLockedPositionOffsetDegrees(value)) {
+            this->parent_->get_nuki_lock_advanced_config()->singleLockedPositionOffsetDegrees = value;
+            this->publish_state(value);
+        }
+    }
 }
 void NukiLockUnlockedToLockedTransitionOffsetDegreesNumber::control(float value) {
-    this->parent_->set_config_number("unlocked_to_locked_transition_offset", value);
+    if (value >= -180 && value <= 180) {
+        if(this->parent_->get_nuki_lock()->setUnlockedToLockedTransitionOffsetDegrees(value)) {
+            this->parent_->get_nuki_lock_advanced_config()->unlockedToLockedTransitionOffsetDegrees = value;
+            this->publish_state(value);
+        }
+    }
 }
 #endif
 
@@ -2446,5 +1867,4 @@ void NukiLockComponent::add_event_log_received_callback(std::function<void(NukiL
     this->event_log_received_callback_.add(std::move(callback));
 }
 
-} //namespace nuki_lock
-} //namespace esphome
+}

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -1371,7 +1371,7 @@ void NukiLockComponent::setup() {
     this->publish_state(lock::LOCK_STATE_NONE);
 
     #ifdef USE_API
-        #ifdef USE_API_SERVICES
+        #ifdef USE_API_CUSTOM_SERVICES
         this->register_service(&NukiLockComponent::lock_n_go, "lock_n_go");
         this->register_service(&NukiLockComponent::print_keypad_entries, "print_keypad_entries");
         this->register_service(&NukiLockComponent::add_keypad_entry, "add_keypad_entry", {"name", "code"});

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -1336,7 +1336,7 @@ void NukiLockComponent::setup() {
             this->event_log_update_ = true;
         }
 
-        const char* pairing_type = this->pairing_as_app_ ? "App" : "Bridge";
+        const char* pairing_type = this->pairing_as_app_.value_or(false) ? "App" : "Bridge";
         const char* lock_type = this->nuki_lock_.isLockUltra() ? "Ultra / Go / 5th Gen" : "1st - 4th Gen";
         ESP_LOGI(TAG, "This component is already paired as %s with a %s smart lock!", pairing_type, lock_type);
 
@@ -1528,7 +1528,7 @@ void NukiLockComponent::update() {
         // Pairing Mode is active
         if (this->pairing_mode_) {
             // Pair Nuki
-            Nuki::AuthorizationIdType type = this->pairing_as_app_ ? Nuki::AuthorizationIdType::App : Nuki::AuthorizationIdType::Bridge;
+            Nuki::AuthorizationIdType type = this->pairing_as_app_.value_or(false) ? Nuki::AuthorizationIdType::App : Nuki::AuthorizationIdType::Bridge;
             
             App.feed_wdt();
             
@@ -1551,7 +1551,7 @@ void NukiLockComponent::update() {
             App.feed_wdt();
 
             if (paired) {
-                const char* pairing_type = this->pairing_as_app_ ? "App" : "Bridge";
+                const char* pairing_type = this->pairing_as_app_.value_or(false) ? "App" : "Bridge";
                 const char* lock_type = this->nuki_lock_.isLockUltra() ? "Ultra / Go / 5th Gen" : "1st - 4th Gen";
                 ESP_LOGI(TAG, "Successfully paired as %s with a %s smart lock!", pairing_type, lock_type);
 
@@ -1805,7 +1805,7 @@ void NukiLockComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  Event: Disabled");
     #endif
 
-    ESP_LOGCONFIG(TAG, "  Pairing Identity: %s",this->pairing_as_app_ ? "App" : "Bridge");
+    ESP_LOGCONFIG(TAG, "  Pairing Identity: %s", this->pairing_as_app_.value_or(false) ? "App" : "Bridge");
     ESP_LOGCONFIG(TAG, "  Is Paired: %s", YESNO(this->is_paired()));
 
     ESP_LOGCONFIG(TAG, "  Pairing mode timeout: %us", this->pairing_mode_timeout_);

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -1531,20 +1531,6 @@ void NukiLockComponent::update() {
             Nuki::AuthorizationIdType type = this->pairing_as_app_.value_or(false) ? Nuki::AuthorizationIdType::App : Nuki::AuthorizationIdType::Bridge;
             
             App.feed_wdt();
-            
-            if (this->security_pin_ != 0) {
-                ESP_LOGW(TAG, "Note: Using security pin override to pair, not yaml config pin!");
-            } else if(this->security_pin_config_.value_or(0) != 0) {
-                ESP_LOGD(TAG, "Using security pin from yaml config to pair.");
-            } else {
-                ESP_LOGW(TAG, "Note: The security pin is crucial to pair a Smart Lock Ultra but is currently not set.");
-            }
-
-            ESP_LOGD(TAG, "NVS pin value (gen 1-4): %d", this->nuki_lock_.getSecurityPincode());
-            ESP_LOGD(TAG, "NVS pin value (ultra/go/gen5): %d", this->nuki_lock_.getUltraPincode());
-
-            ESP_LOGD(TAG, "ESPHome pin value (gen 1-4): %d", this->security_pin_);
-            ESP_LOGD(TAG, "ESPHome pin value (ultra/go/gen5): %d", this->security_pin_config_.value_or(0));
 
             bool paired = this->nuki_lock_.pairNuki(type) == Nuki::PairingResult::Success;
 
@@ -1964,6 +1950,20 @@ void NukiLockComponent::set_pairing_mode(bool enabled) {
     if (enabled) {
         ESP_LOGI(TAG, "Pairing Mode turned on for %d seconds", this->pairing_mode_timeout_);
         this->pairing_mode_on_callback_.call();
+
+        if (this->security_pin_ != 0) {
+            ESP_LOGW(TAG, "Note: Using security pin override to pair, not yaml config pin!");
+        } else if(this->security_pin_config_.value_or(0) != 0) {
+            ESP_LOGD(TAG, "Using security pin from yaml config to pair.");
+        } else {
+            ESP_LOGW(TAG, "Note: The security pin is crucial to pair a Smart Lock Ultra but is currently not set.");
+        }
+
+        ESP_LOGD(TAG, "NVS pin value (gen 1-4): %d", this->nuki_lock_.getSecurityPincode());
+        ESP_LOGD(TAG, "NVS pin value (ultra/go/gen5): %d", this->nuki_lock_.getUltraPincode());
+
+        ESP_LOGD(TAG, "ESPHome pin value (override): %d", this->security_pin_);
+        ESP_LOGD(TAG, "ESPHome pin value (yaml config): %d", this->security_pin_config_.value_or(0));
 
         ESP_LOGI(TAG, "Waiting for Nuki to enter pairing mode...");
 

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -1309,7 +1309,7 @@ void NukiLockComponent::setup() {
         }
     }
 
-    this->nuki_lock_.setDebugConnect(false);
+    this->nuki_lock_.setDebugConnect(true);
     this->nuki_lock_.setDebugCommunication(false);
     this->nuki_lock_.setDebugReadableData(false);
     this->nuki_lock_.setDebugHexData(false);

--- a/components/nuki_lock/nuki_lock.cpp
+++ b/components/nuki_lock/nuki_lock.cpp
@@ -1108,7 +1108,7 @@ const char* NukiLockComponent::get_auth_name(uint32_t authId) const {
 bool NukiLockComponent::execute_lock_action(NukiLock::LockAction lock_action) {
     if (!this->nuki_lock_.isPairedWithLock()) {
         ESP_LOGE(TAG, "Lock is not paired, cannot execute lock action");
-        return;
+        return false;
     }
 
     // Publish the assumed transitional lock state

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -168,7 +168,6 @@ class NukiLockComponent :
         void notify(Nuki::EventType event_type) override;
         float get_setup_priority() const override { return setup_priority::HARDWARE - 1.0f; }
 
-        void set_pairing_as_app(bool pairing_as_app) { this->pairing_as_app_ = pairing_as_app; }
         void set_pairing_mode_timeout(uint32_t pairing_mode_timeout) { this->pairing_mode_timeout_ = pairing_mode_timeout; }
         void set_query_interval_config(uint32_t query_interval_config) { this->query_interval_config_ = query_interval_config; }
         void set_query_interval_auth_data(uint32_t query_interval_auth_data) { this->query_interval_auth_data_ = query_interval_auth_data; }
@@ -182,6 +181,7 @@ class NukiLockComponent :
         }
 
         template<typename T> void set_security_pin_config(T security_pin_config) { this->security_pin_config_ = security_pin_config; }
+        template<typename T> void set_pairing_as_app(T pairing_as_app) { this->pairing_as_app_ = pairing_as_app; }
 
         void add_pairing_mode_on_callback(std::function<void()> &&callback);
         void add_pairing_mode_off_callback(std::function<void()> &&callback);
@@ -286,12 +286,12 @@ class NukiLockComponent :
         bool event_log_update_;
         bool open_latch_;
         bool lock_n_go_;
-
-        bool pairing_as_app_ = false;
-
+        
         PinState pin_state_ = PinState::NotSet;
         uint32_t security_pin_ = 0;
         TemplatableValue<uint32_t> security_pin_config_{};
+
+        TemplatableValue<bool> pairing_as_app_{};
 
         bool connected_ = false;
 

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -166,7 +166,7 @@ class NukiLockComponent :
         void update() override;
         void dump_config() override;
         void notify(Nuki::EventType event_type) override;
-        float get_setup_priority() const override { return setup_priority::HARDWARE; }
+        float get_setup_priority() const override { return setup_priority::AFTER_BLUETOOTH; }
 
         void set_pairing_mode_timeout(uint32_t pairing_mode_timeout) { this->pairing_mode_timeout_ = pairing_mode_timeout; }
         void set_query_interval_config(uint32_t query_interval_config) { this->query_interval_config_ = query_interval_config; }

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -166,7 +166,7 @@ class NukiLockComponent :
         void update() override;
         void dump_config() override;
         void notify(Nuki::EventType event_type) override;
-        float get_setup_priority() const override { return setup_priority::AFTER_BLUETOOTH; }
+        float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
         void set_pairing_mode_timeout(uint32_t pairing_mode_timeout) { this->pairing_mode_timeout_ = pairing_mode_timeout; }
         void set_query_interval_config(uint32_t query_interval_config) { this->query_interval_config_ = query_interval_config; }

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -107,6 +107,8 @@ class NukiLockComponent :
     SUB_NUMBER(led_brightness)
     SUB_NUMBER(timezone_offset)
     SUB_NUMBER(lock_n_go_timeout)
+    SUB_NUMBER(auto_lock_timeout)
+    SUB_NUMBER(unlatch_duration)
     #endif
     #ifdef USE_SELECT
     SUB_SELECT(single_button_press_action)
@@ -121,9 +123,11 @@ class NukiLockComponent :
     #endif
     #ifdef USE_BUTTON
     SUB_BUTTON(unpair)
+    SUB_BUTTON(request_calibration)
     #endif
     #ifdef USE_SWITCH
     SUB_SWITCH(pairing_mode)
+    SUB_SWITCH(pairing_enabled)
     SUB_SWITCH(button_enabled)
     SUB_SWITCH(auto_unlatch_enabled)
     SUB_SWITCH(led_enabled)
@@ -213,6 +217,8 @@ class NukiLockComponent :
         void unpair();
         void set_pairing_mode(bool enabled);
         void save_settings();
+
+        void request_calibration();
 
         bool is_connected() {
             return this->connected_;
@@ -324,6 +330,13 @@ class NukiLockUnpairButton : public button::Button, public Parented<NukiLockComp
     protected:
         void press_action() override;
 };
+
+class NukiLockRequestCalibrationButton : public button::Button, public Parented<NukiLockComponent> {
+    public:
+        NukiLockRequestCalibrationButton() = default;
+    protected:
+        void press_action() override;
+};
 #endif
 
 #ifdef USE_SELECT
@@ -395,6 +408,13 @@ class NukiLockMotorSpeedSelect : public select::Select, public Parented<NukiLock
 class NukiLockPairingModeSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
     public:
         NukiLockPairingModeSwitch() = default;
+    protected:
+        void write_state(bool state) override;
+};
+
+class NukiLockPairingEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
+    public:
+        NukiLockPairingEnabledSwitch() = default;
     protected:
         void write_state(bool state) override;
 };
@@ -538,6 +558,21 @@ class NukiLockTimeZoneOffsetNumber : public number::Number, public Parented<Nuki
 class NukiLockLockNGoTimeoutNumber : public number::Number, public Parented<NukiLockComponent> {
     public:
         NukiLockLockNGoTimeoutNumber() = default;
+
+    protected:
+        void control(float value) override;
+};
+class NukiLockAutoLockTimeoutNumber : public number::Number, public Parented<NukiLockComponent> {
+    public:
+        NukiLockAutoLockTimeoutNumber() = default;
+
+    protected:
+        void control(float value) override;
+};
+
+class NukiLockUnlatchDurationNumber : public number::Number, public Parented<NukiLockComponent> {
+    public:
+        NukiLockUnlatchDurationNumber() = default;
 
     protected:
         void control(float value) override;

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -109,6 +109,10 @@ class NukiLockComponent :
     SUB_NUMBER(lock_n_go_timeout)
     SUB_NUMBER(auto_lock_timeout)
     SUB_NUMBER(unlatch_duration)
+    SUB_NUMBER(unlocked_position_offset)
+    SUB_NUMBER(locked_position_offset)
+    SUB_NUMBER(single_locked_position_offset)
+    SUB_NUMBER(unlocked_to_locked_transition_offset)
     #endif
     #ifdef USE_SELECT
     SUB_SELECT(single_button_press_action)
@@ -143,6 +147,7 @@ class NukiLockComponent :
     SUB_SWITCH(dst_mode_enabled)
     SUB_SWITCH(auto_battery_type_detection_enabled)
     SUB_SWITCH(slow_speed_during_night_mode_enabled)
+    SUB_SWITCH(detached_cylinder_enabled)
     #endif
 
     public:
@@ -538,6 +543,14 @@ class NukiLockSlowSpeedDuringNightModeEnabledSwitch : public switch_::Switch, pu
     protected:
         void write_state(bool state) override;
 };
+
+class NukiLockDetachedCylinderEnabledSwitch : public switch_::Switch, public Parented<NukiLockComponent> {
+    public:
+        NukiLockDetachedCylinderEnabledSwitch() = default;
+
+    protected:
+        void write_state(bool state) override;
+};
 #endif
 
 #ifdef USE_NUMBER
@@ -573,6 +586,38 @@ class NukiLockAutoLockTimeoutNumber : public number::Number, public Parented<Nuk
 class NukiLockUnlatchDurationNumber : public number::Number, public Parented<NukiLockComponent> {
     public:
         NukiLockUnlatchDurationNumber() = default;
+
+    protected:
+        void control(float value) override;
+};
+
+class NukiLockUnlockedPositionOffsetDegreesNumber : public number::Number, public Parented<NukiLockComponent> {
+    public:
+        NukiLockUnlockedPositionOffsetDegreesNumber() = default;
+
+    protected:
+        void control(float value) override;
+};
+
+class NukiLockLockedPositionOffsetDegreesNumber : public number::Number, public Parented<NukiLockComponent> {
+    public:
+        NukiLockLockedPositionOffsetDegreesNumber() = default;
+
+    protected:
+        void control(float value) override;
+};
+
+class NukiLockSingleLockedPositionOffsetDegreesNumber : public number::Number, public Parented<NukiLockComponent> {
+    public:
+        NukiLockSingleLockedPositionOffsetDegreesNumber() = default;
+
+    protected:
+        void control(float value) override;
+};
+
+class NukiLockUnlockedToLockedTransitionOffsetDegreesNumber : public number::Number, public Parented<NukiLockComponent> {
+    public:
+        NukiLockUnlockedToLockedTransitionOffsetDegreesNumber() = default;
 
     protected:
         void control(float value) override;

--- a/components/nuki_lock/nuki_lock.h
+++ b/components/nuki_lock/nuki_lock.h
@@ -166,7 +166,7 @@ class NukiLockComponent :
         void update() override;
         void dump_config() override;
         void notify(Nuki::EventType event_type) override;
-        float get_setup_priority() const override { return setup_priority::HARDWARE - 1.0f; }
+        float get_setup_priority() const override { return setup_priority::AFTER_BLUETOOTH; }
 
         void set_pairing_mode_timeout(uint32_t pairing_mode_timeout) { this->pairing_mode_timeout_ = pairing_mode_timeout; }
         void set_query_interval_config(uint32_t query_interval_config) { this->query_interval_config_ = query_interval_config; }

--- a/components/nuki_lock/utils.cpp
+++ b/components/nuki_lock/utils.cpp
@@ -1,0 +1,499 @@
+#include "utils.h"
+#include <cstring>
+
+#include "esphome/components/lock/lock.h"
+#include "NukiLock.h"
+
+namespace esphome::nuki_lock {
+    lock::LockState nuki_to_lock_state(NukiLock::LockState nukiLockState) {
+        switch(nukiLockState) {
+            case NukiLock::LockState::Locked:
+                return lock::LOCK_STATE_LOCKED;
+            case NukiLock::LockState::Unlocked:
+            case NukiLock::LockState::Unlatched:
+                return lock::LOCK_STATE_UNLOCKED;
+            case NukiLock::LockState::MotorBlocked:
+                return lock::LOCK_STATE_JAMMED;
+            case NukiLock::LockState::Locking:
+                return lock::LOCK_STATE_LOCKING;
+            case NukiLock::LockState::Unlocking:
+            case NukiLock::LockState::Unlatching:
+                return lock::LOCK_STATE_UNLOCKING;
+            default:
+                return lock::LOCK_STATE_NONE;
+        }
+    }
+
+    bool nuki_doorsensor_to_binary(Nuki::DoorSensorState nuki_door_sensor_state) {
+        if (nuki_door_sensor_state == Nuki::DoorSensorState::DoorClosed) {
+            return false;
+        }
+        return true;
+    }
+
+    NukiLock::ButtonPressAction button_press_action_to_enum(const char* str)
+    {
+        if (strcmp(str, "No action") == 0) {
+            return NukiLock::ButtonPressAction::NoAction;
+        } else if (strcmp(str, "Intelligent") == 0) {
+            return NukiLock::ButtonPressAction::Intelligent;
+        } else if (strcmp(str, "Unlock") == 0) {
+            return NukiLock::ButtonPressAction::Unlock;
+        } else if (strcmp(str, "Lock") == 0) {
+            return NukiLock::ButtonPressAction::Lock;
+        } else if (strcmp(str, "Open door") == 0) {
+            return NukiLock::ButtonPressAction::Unlatch;
+        } else if (strcmp(str, "Lock 'n' Go") == 0) {
+            return NukiLock::ButtonPressAction::LockNgo;
+        } else if (strcmp(str, "Show state") == 0) {
+            return NukiLock::ButtonPressAction::ShowStatus;
+        }
+        return NukiLock::ButtonPressAction::NoAction;
+    }
+
+    void button_press_action_to_string(const NukiLock::ButtonPressAction action, char* str) {
+        switch (action) {
+            case NukiLock::ButtonPressAction::NoAction:
+                strcpy(str, "No action");
+                break;
+            case NukiLock::ButtonPressAction::Intelligent:
+                strcpy(str, "Intelligent");
+                break;
+            case NukiLock::ButtonPressAction::Unlock:
+                strcpy(str, "Unlock");
+                break;
+            case NukiLock::ButtonPressAction::Lock:
+                strcpy(str, "Lock");
+                break;
+            case NukiLock::ButtonPressAction::Unlatch:
+                strcpy(str, "Open door");
+                break;
+            case NukiLock::ButtonPressAction::LockNgo:
+                strcpy(str, "Lock 'n' Go");
+                break;
+            case NukiLock::ButtonPressAction::ShowStatus:
+                strcpy(str, "Show state");
+                break;
+            default:
+                strcpy(str, "No action");
+                break;
+        }
+    }
+
+    void battery_type_to_string(const Nuki::BatteryType battery_type, char* str) {
+        switch (battery_type) {
+            case Nuki::BatteryType::Alkali:
+                strcpy(str, "Alkali");
+                break;
+            case Nuki::BatteryType::Accumulators:
+                strcpy(str, "Accumulators");
+                break;
+            case Nuki::BatteryType::Lithium:
+                strcpy(str, "Lithium");
+                break;
+            default:
+                strcpy(str, "undefined");
+                break;
+        }
+    }
+
+    Nuki::BatteryType battery_type_to_enum(const char* str) {
+        if(strcmp(str, "Alkali") == 0) {
+            return Nuki::BatteryType::Alkali;
+        } else if(strcmp(str, "Accumulators") == 0) {
+            return Nuki::BatteryType::Accumulators;
+        } else if(strcmp(str, "Lithium") == 0) {
+            return Nuki::BatteryType::Lithium;
+        }
+        return (Nuki::BatteryType)0xff;
+    }
+
+    void homekit_status_to_string(const int status, char* str) {
+        switch (status) {
+            case 0:
+                strcpy(str, "Not Available");
+                break;
+            case 1:
+                strcpy(str, "Disabled");
+                break;
+            case 2:
+                strcpy(str, "Enabled");
+                break;
+            case 3:
+                strcpy(str, "Enabled & Paired");
+                break;
+            default:
+                strcpy(str, "undefined");
+                break;
+        }
+    }
+
+    void motor_speed_to_string(const NukiLock::MotorSpeed speed, char* str) {
+        switch (speed) {
+            case NukiLock::MotorSpeed::Standard:
+                strcpy(str, "Standard");
+                break;
+            case NukiLock::MotorSpeed::Insane:
+                strcpy(str, "Insane");
+                break;
+            case NukiLock::MotorSpeed::Gentle:
+                strcpy(str, "Gentle");
+                break;
+            default:
+                strcpy(str, "undefined");
+                break;
+        }
+    }
+
+    NukiLock::MotorSpeed motor_speed_to_enum(const char* str) {
+        if(strcmp(str, "Standard") == 0) {
+            return NukiLock::MotorSpeed::Standard;
+        } else if(strcmp(str, "Insane") == 0) {
+            return NukiLock::MotorSpeed::Insane;
+        } else if(strcmp(str, "Gentle") == 0) {
+            return NukiLock::MotorSpeed::Gentle;
+        }
+        return NukiLock::MotorSpeed::Standard;
+    }
+
+    uint8_t fob_action_to_int(const char *str) {
+        if(strcmp(str, "No action") == 0) {
+            return 0;
+        } else if(strcmp(str, "Unlock") == 0) {
+            return 1;
+        } else if(strcmp(str, "Lock") == 0) {
+            return 2;
+        } else if(strcmp(str, "Lock 'n' Go") == 0) {
+            return 3;
+        } else if(strcmp(str, "Intelligent") == 0) {
+            return 4;
+        }
+        return 99;
+    }
+
+    void fob_action_to_string(const int action, char* str) {
+        switch (action) {
+            case 0:
+                strcpy(str, "No action");
+                break;
+            case 1:
+                strcpy(str, "Unlock");
+                break;
+            case 2:
+                strcpy(str, "Lock");
+                break;
+            case 3:
+                strcpy(str, "Lock 'n' Go");
+                break;
+            case 4:
+                strcpy(str, "Intelligent");
+                break;
+            default:
+                strcpy(str, "No action");
+                break;
+        }
+    }
+
+    Nuki::TimeZoneId timezone_to_enum(const char *str) {
+        if(strcmp(str, "Africa/Cairo") == 0) {
+            return Nuki::TimeZoneId::Africa_Cairo;
+        } else if(strcmp(str, "Africa/Lagos") == 0) {
+            return Nuki::TimeZoneId::Africa_Lagos;
+        } else if(strcmp(str, "Africa/Maputo") == 0) {
+            return Nuki::TimeZoneId::Africa_Maputo;
+        } else if(strcmp(str, "Africa/Nairobi") == 0) {
+            return Nuki::TimeZoneId::Africa_Nairobi;
+        } else if(strcmp(str, "America/Anchorage") == 0) {
+            return Nuki::TimeZoneId::America_Anchorage;
+        } else if(strcmp(str, "America/Argentina/Buenos_Aires") == 0) {
+            return Nuki::TimeZoneId::America_Argentina_Buenos_Aires;
+        } else if(strcmp(str, "America/Chicago") == 0) {
+            return Nuki::TimeZoneId::America_Chicago;
+        } else if(strcmp(str, "America/Denver") == 0) {
+            return Nuki::TimeZoneId::America_Denver;
+        } else if(strcmp(str, "America/Halifax") == 0) {
+            return Nuki::TimeZoneId::America_Halifax;
+        } else if(strcmp(str, "America/Los_Angeles") == 0) {
+            return Nuki::TimeZoneId::America_Los_Angeles;
+        } else if(strcmp(str, "America/Manaus") == 0) {
+            return Nuki::TimeZoneId::America_Manaus;
+        } else if(strcmp(str, "America/Mexico_City") == 0) {
+            return Nuki::TimeZoneId::America_Mexico_City;
+        } else if(strcmp(str, "America/New_York") == 0) {
+            return Nuki::TimeZoneId::America_New_York;
+        } else if(strcmp(str, "America/Phoenix") == 0) {
+            return Nuki::TimeZoneId::America_Phoenix;
+        } else if(strcmp(str, "America/Regina") == 0) {
+            return Nuki::TimeZoneId::America_Regina;
+        } else if(strcmp(str, "America/Santiago") == 0) {
+            return Nuki::TimeZoneId::America_Santiago;
+        } else if(strcmp(str, "America/Sao_Paulo") == 0) {
+            return Nuki::TimeZoneId::America_Sao_Paulo;
+        } else if(strcmp(str, "America/St_Johns") == 0) {
+            return Nuki::TimeZoneId::America_St_Johns;
+        } else if(strcmp(str, "Asia/Bangkok") == 0) {
+            return Nuki::TimeZoneId::Asia_Bangkok;
+        } else if(strcmp(str, "Asia/Dubai") == 0) {
+            return Nuki::TimeZoneId::Asia_Dubai;
+        } else if(strcmp(str, "Asia/Hong_Kong") == 0) {
+            return Nuki::TimeZoneId::Asia_Hong_Kong;
+        } else if(strcmp(str, "Asia/Jerusalem") == 0) {
+            return Nuki::TimeZoneId::Asia_Jerusalem;
+        } else if(strcmp(str, "Asia/Karachi") == 0) {
+            return Nuki::TimeZoneId::Asia_Karachi;
+        } else if(strcmp(str, "Asia/Kathmandu") == 0) {
+            return Nuki::TimeZoneId::Asia_Kathmandu;
+        } else if(strcmp(str, "Asia/Kolkata") == 0) {
+            return Nuki::TimeZoneId::Asia_Kolkata;
+        } else if(strcmp(str, "Asia/Riyadh") == 0) {
+            return Nuki::TimeZoneId::Asia_Riyadh;
+        } else if(strcmp(str, "Asia/Seoul") == 0) {
+            return Nuki::TimeZoneId::Asia_Seoul;
+        } else if(strcmp(str, "Asia/Shanghai") == 0) {
+            return Nuki::TimeZoneId::Asia_Shanghai;
+        } else if(strcmp(str, "Asia/Tehran") == 0) {
+            return Nuki::TimeZoneId::Asia_Tehran;
+        } else if(strcmp(str, "Asia/Tokyo") == 0) {
+            return Nuki::TimeZoneId::Asia_Tokyo;
+        } else if(strcmp(str, "Asia/Yangon") == 0) {
+            return Nuki::TimeZoneId::Asia_Yangon;
+        } else if(strcmp(str, "Australia/Adelaide") == 0) {
+            return Nuki::TimeZoneId::Australia_Adelaide;
+        } else if(strcmp(str, "Australia/Brisbane") == 0) {
+            return Nuki::TimeZoneId::Australia_Brisbane;
+        } else if(strcmp(str, "Australia/Darwin") == 0) {
+            return Nuki::TimeZoneId::Australia_Darwin;
+        } else if(strcmp(str, "Australia/Hobart") == 0) {
+            return Nuki::TimeZoneId::Australia_Hobart;
+        } else if(strcmp(str, "Australia/Perth") == 0) {
+            return Nuki::TimeZoneId::Australia_Perth;
+        } else if(strcmp(str, "Australia/Sydney") == 0) {
+            return Nuki::TimeZoneId::Australia_Sydney;
+        } else if(strcmp(str, "Europe/Berlin") == 0) {
+            return Nuki::TimeZoneId::Europe_Berlin;
+        } else if(strcmp(str, "Europe/Helsinki") == 0) {
+            return Nuki::TimeZoneId::Europe_Helsinki;
+        } else if(strcmp(str, "Europe/Istanbul") == 0) {
+            return Nuki::TimeZoneId::Europe_Istanbul;
+        } else if(strcmp(str, "Europe/London") == 0) {
+            return Nuki::TimeZoneId::Europe_London;
+        } else if(strcmp(str, "Europe/Moscow") == 0) {
+            return Nuki::TimeZoneId::Europe_Moscow;
+        } else if(strcmp(str, "Pacific/Auckland") == 0) {
+            return Nuki::TimeZoneId::Pacific_Auckland;
+        } else if(strcmp(str, "Pacific/Guam") == 0) {
+            return Nuki::TimeZoneId::Pacific_Guam;
+        } else if(strcmp(str, "Pacific/Honolulu") == 0) {
+            return Nuki::TimeZoneId::Pacific_Honolulu;
+        } else if(strcmp(str, "Pacific/Pago_Pago") == 0) {
+            return Nuki::TimeZoneId::Pacific_Pago_Pago;
+        } else if(strcmp(str, "None") == 0) {
+            return Nuki::TimeZoneId::None;
+        }
+        return (Nuki::TimeZoneId)0xff;
+    }
+
+    void timezone_to_string(const Nuki::TimeZoneId timeZoneId, char* str) {
+        switch (timeZoneId) {
+            case Nuki::TimeZoneId::Africa_Cairo:
+                strcpy(str, "Africa/Cairo");
+                break;
+            case Nuki::TimeZoneId::Africa_Lagos:
+                strcpy(str, "Africa/Lagos");
+                break;
+            case Nuki::TimeZoneId::Africa_Maputo:
+                strcpy(str, "Africa/Maputo");
+                break;
+            case Nuki::TimeZoneId::Africa_Nairobi:
+                strcpy(str, "Africa/Nairobi");
+                break;
+            case Nuki::TimeZoneId::America_Anchorage:
+                strcpy(str, "America/Anchorage");
+                break;
+            case Nuki::TimeZoneId::America_Argentina_Buenos_Aires:
+                strcpy(str, "America/Argentina/Buenos_Aires");
+                break;
+            case Nuki::TimeZoneId::America_Chicago:
+                strcpy(str, "America/Chicago");
+                break;
+            case Nuki::TimeZoneId::America_Denver:
+                strcpy(str, "America/Denver");
+                break;
+            case Nuki::TimeZoneId::America_Halifax:
+                strcpy(str, "America/Halifax");
+                break;
+            case Nuki::TimeZoneId::America_Los_Angeles:
+                strcpy(str, "America/Los_Angeles");
+                break;
+            case Nuki::TimeZoneId::America_Manaus:
+                strcpy(str, "America/Manaus");
+                break;
+            case Nuki::TimeZoneId::America_Mexico_City:
+                strcpy(str, "America/Mexico_City");
+                break;
+            case Nuki::TimeZoneId::America_New_York:
+                strcpy(str, "America/New_York");
+                break;
+            case Nuki::TimeZoneId::America_Phoenix:
+                strcpy(str, "America/Phoenix");
+                break;
+            case Nuki::TimeZoneId::America_Regina:
+                strcpy(str, "America/Regina");
+                break;
+            case Nuki::TimeZoneId::America_Santiago:
+                strcpy(str, "America/Santiago");
+                break;
+            case Nuki::TimeZoneId::America_Sao_Paulo:
+                strcpy(str, "America/Sao_Paulo");
+                break;
+            case Nuki::TimeZoneId::America_St_Johns:
+                strcpy(str, "America/St_Johns");
+                break;
+            case Nuki::TimeZoneId::Asia_Bangkok:
+                strcpy(str, "Asia/Bangkok");
+                break;
+            case Nuki::TimeZoneId::Asia_Dubai:
+                strcpy(str, "Asia/Dubai");
+                break;
+            case Nuki::TimeZoneId::Asia_Hong_Kong:
+                strcpy(str, "Asia/Hong_Kong");
+                break;
+            case Nuki::TimeZoneId::Asia_Jerusalem:
+                strcpy(str, "Asia/Jerusalem");
+                break;
+            case Nuki::TimeZoneId::Asia_Karachi:
+                strcpy(str, "Asia/Karachi");
+                break;
+            case Nuki::TimeZoneId::Asia_Kathmandu:
+                strcpy(str, "Asia/Kathmandu");
+                break;
+            case Nuki::TimeZoneId::Asia_Kolkata:
+                strcpy(str, "Asia/Kolkata");
+                break;
+            case Nuki::TimeZoneId::Asia_Riyadh:
+                strcpy(str, "Asia/Riyadh");
+                break;
+            case Nuki::TimeZoneId::Asia_Seoul:
+                strcpy(str, "Asia/Seoul");
+                break;
+            case Nuki::TimeZoneId::Asia_Shanghai:
+                strcpy(str, "Asia/Shanghai");
+                break;
+            case Nuki::TimeZoneId::Asia_Tehran:
+                strcpy(str, "Asia/Tehran");
+                break;
+            case Nuki::TimeZoneId::Asia_Tokyo:
+                strcpy(str, "Asia/Tokyo");
+                break;
+            case Nuki::TimeZoneId::Asia_Yangon:
+                strcpy(str, "Asia/Yangon");
+                break;
+            case Nuki::TimeZoneId::Australia_Adelaide:
+                strcpy(str, "Australia/Adelaide");
+                break;
+            case Nuki::TimeZoneId::Australia_Brisbane:
+                strcpy(str, "Australia/Brisbane");
+                break;
+            case Nuki::TimeZoneId::Australia_Darwin:
+                strcpy(str, "Australia/Darwin");
+                break;
+            case Nuki::TimeZoneId::Australia_Hobart:
+                strcpy(str, "Australia/Hobart");
+                break;
+            case Nuki::TimeZoneId::Australia_Perth:
+                strcpy(str, "Australia/Perth");
+                break;
+            case Nuki::TimeZoneId::Australia_Sydney:
+                strcpy(str, "Australia/Sydney");
+                break;
+            case Nuki::TimeZoneId::Europe_Berlin:
+                strcpy(str, "Europe/Berlin");
+                break;
+            case Nuki::TimeZoneId::Europe_Helsinki:
+                strcpy(str, "Europe/Helsinki");
+                break;
+            case Nuki::TimeZoneId::Europe_Istanbul:
+                strcpy(str, "Europe/Istanbul");
+                break;
+            case Nuki::TimeZoneId::Europe_London:
+                strcpy(str, "Europe/London");
+                break;
+            case Nuki::TimeZoneId::Europe_Moscow:
+                strcpy(str, "Europe/Moscow");
+                break;
+            case Nuki::TimeZoneId::Pacific_Auckland:
+                strcpy(str, "Pacific/Auckland");
+                break;
+            case Nuki::TimeZoneId::Pacific_Guam:
+                strcpy(str, "Pacific/Guam");
+                break;
+            case Nuki::TimeZoneId::Pacific_Honolulu:
+                strcpy(str, "Pacific/Honolulu");
+                break;
+            case Nuki::TimeZoneId::Pacific_Pago_Pago:
+                strcpy(str, "Pacific/Pago_Pago");
+                break;
+            case Nuki::TimeZoneId::None:
+                strcpy(str, "None");
+                break;
+            default:
+                strcpy(str, "None");
+                break;
+        }
+    }
+
+    Nuki::AdvertisingMode advertising_mode_to_enum(const char *str) {
+        if(strcmp(str, "Automatic") == 0) {
+            return Nuki::AdvertisingMode::Automatic;
+        } else if(strcmp(str, "Normal") == 0) {
+            return Nuki::AdvertisingMode::Normal;
+        } else if(strcmp(str, "Slow") == 0) {
+            return Nuki::AdvertisingMode::Slow;
+        } else if(strcmp(str, "Slowest") == 0) {
+            return Nuki::AdvertisingMode::Slowest;
+        }
+        return (Nuki::AdvertisingMode)0xff;
+    }
+
+    void advertising_mode_to_string(const Nuki::AdvertisingMode mode, char* str) {
+        switch (mode) {
+            case Nuki::AdvertisingMode::Automatic:
+                strcpy(str, "Automatic");
+                break;
+            case Nuki::AdvertisingMode::Normal:
+                strcpy(str, "Normal");
+                break;
+            case Nuki::AdvertisingMode::Slow:
+                strcpy(str, "Slow");
+                break;
+            case Nuki::AdvertisingMode::Slowest:
+                strcpy(str, "Slowest");
+                break;
+            default:
+                strcpy(str, "Normal");
+                break;
+        }
+    }
+
+    void pin_state_to_string(const PinState value, char* str)
+    {
+        switch(value)
+        {
+            case PinState::NotSet:
+                strcpy(str, "Not set");
+                break;
+            case PinState::Set:
+                strcpy(str, "Validation pending");
+                break;
+            case PinState::Valid:
+                strcpy(str, "Valid");
+                break;
+            case PinState::Invalid:
+                strcpy(str, "Invalid");
+                break;
+            default:
+                strcpy(str, "Unknown");
+                break;
+        }
+    }
+}

--- a/components/nuki_lock/utils.h
+++ b/components/nuki_lock/utils.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "esphome/components/lock/lock.h"
+#include "NukiLock.h"
+
+namespace esphome::nuki_lock {
+    enum PinState
+    {
+        NotSet = 0,
+        Set = 1,
+        Valid = 2,
+        Invalid = 3
+    };
+
+    lock::LockState nuki_to_lock_state(NukiLock::LockState);
+    
+    bool nuki_doorsensor_to_binary(Nuki::DoorSensorState);
+    
+    uint8_t fob_action_to_int(const char *str);
+    void fob_action_to_string(const int action, char* str);
+    
+    Nuki::BatteryType battery_type_to_enum(const char* str);
+    void battery_type_to_string(const Nuki::BatteryType battery_type, char* str);
+    
+    NukiLock::MotorSpeed motor_speed_to_enum(const char* str);
+    void motor_speed_to_string(const NukiLock::MotorSpeed speed, char* str);
+    
+    NukiLock::ButtonPressAction button_press_action_to_enum(const char* str);
+    void button_press_action_to_string(NukiLock::ButtonPressAction action, char* str);
+    
+    Nuki::TimeZoneId timezone_to_enum(const char *str);
+    void timezone_to_string(const Nuki::TimeZoneId timeZoneId, char* str);
+    
+    Nuki::AdvertisingMode advertising_mode_to_enum(const char *str);
+    void advertising_mode_to_string(const Nuki::AdvertisingMode mode, char* str);
+    
+    void homekit_status_to_string(const int status, char* str);
+    void pin_state_to_string(const PinState value, char* str);
+}


### PR DESCRIPTION
The nuki component blocks the main loop for too long, creating timing issues with other components.
I moved the nuki logic to a separate nuki task - this solved the loop blocking issue.

Please give it a try and let me know about the stability compared to the current version.

I also moved conversion utility functions to another file to cleanup.