### PR TITLE
Fix typo in slow speed night mode setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ lock:
       name: "Nuki Daylight Saving Time"
     auto_battery_type_detection_enabled:
       name: "Nuki Automatic Battery Type Detection"
-    slow_speed_during_night_mode_enabled:
+    slow_speed_during_night_mode:
       name: "Nuki Slow Speed During Night Mode"
     detached_cylinder_enabled:
       name: "Nuki Detached Cylinder"


### PR DESCRIPTION
There is a typo in night mode ->
CONF_SLOW_SPEED_DURING_NIGHT_MODE_ENABLED_SWITCH = "slow_speed_during_night_mode"